### PR TITLE
Add cherrypicker and enable for all Maistra repositories

### DIFF
--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: cherrypicker
+  labels:
+    app.kubernetes.io/part-of: prow
+    app: cherrypicker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cherrypicker
+  template:
+    metadata:
+      labels:
+        app: cherrypicker
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: cherrypicker
+        image: gcr.io/k8s-prow/cherrypicker:v20200417-a6017ee5b
+        args:
+        - --dry-run=false
+        - --use-prow-assignments=false
+        - --github-endpoint=https://api.github.com
+        ports:
+        - name: http
+          containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token

--- a/prow/cluster/cherrypicker_service.yaml
+++ b/prow/cluster/cherrypicker_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/part-of: prow
+    app: cherrypicker
+  namespace: default
+  name: cherrypicker
+spec:
+  selector:
+    app: cherrypicker
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  type: ClusterIP

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -28,3 +28,17 @@ plugins:
   - lgtm
   - hold
   - wip
+
+
+external_plugins:
+  Maistra:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
+      
+  maistra-prow-testing:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION
Should be fine to enable on all repositories because it only reacts to comments - just comment `/cherry-pick <target-branch>` on any PR and it will be cherry-picked after merge.

@bartoszmajsak @aslakknutsen let me know if you explicitly don't want me to enable this for istio-workspace.