### PR TITLE
Miscelaneous fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ You should have existing secrets for an already running cluster. You'll only nee
 ### Deploying Prow from Scratch
 
 1. Run `cd prow && ./create.sh`
-1. Add the webhook URL to the GitHub Org: https://github.com/organizations/<org>/settings/hooks - the URL is https://<prow-url>/hook
+1. Add the webhook URL to the GitHub Org: `https://github.com/organizations/<org>/settings/hooks`
+   - Payload URL: `https://<prow-url>/hook`
+   - Content type: `application/json`
+   - Secret: the contents of `prow/secrets/github-hmac-secret`
 
 ### Known Issues
 

--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -17,6 +17,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: "crier"
+  namespace: "default"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/prow/create.sh
+++ b/prow/create.sh
@@ -6,16 +6,18 @@ set -ex
 kubectl create namespace test-pods || echo Skipping
 
 # create configmaps
-kubectl create cm config || echo Skipping
-kubectl create cm plugins || echo Skipping
+kubectl -n default create cm config || echo Skipping
+kubectl -n default create cm plugins || echo Skipping
 
 # create secrets
-kubectl create secret generic hmac-token --from-file=hmac=secrets/github-hmac-secret
-kubectl create secret generic cookie --from-file=secret=secrets/cookie-secret
-kubectl create secret generic oauth-token --from-file=oauth=secrets/github-token
+kubectl -n default create secret generic hmac-token --from-file=hmac=secrets/github-hmac-secret
+kubectl -n default create secret generic cookie --from-file=secret=secrets/cookie-secret
+kubectl -n default create secret generic oauth-token --from-file=oauth=secrets/github-token
 
-kubectl create secret generic gcs-credentials -n test-pods --from-file=service-account.json=secrets/gcs-credentials.json
-kubectl create secret generic quay-pusher-dockercfg -n test-pods --from-file=config.json=secrets/maistra-prow-auth.json
+kubectl -n test-pods create secret generic github-token --from-file=github-token=secrets/github-token || echo Skipping
+kubectl -n test-pods create secret generic gcs-credentials --from-file=service-account.json=secrets/gcs-credentials.json || echo Skipping
+kubectl -n test-pods create secret generic quay-pusher-dockercfg --from-file=config.json=secrets/maistra-prow-auth.json || echo Skipping
+kubectl -n test-pods create secret generic copr --from-file=copr=secrets/copr-token-bot || echo Skipping
 
 # create service account including secret holding kubeconfig (for auto-updating prow config on merged PRs)
 ./setup-prow-deployer.sh
@@ -29,6 +31,7 @@ helm template --name ingress --namespace ingress \
 # install cert-manager
 kubectl create namespace cert-manager || echo Skipping
 kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml
+sleep 10
 
 # deploy prow
 ./update.sh

--- a/prow/setup-prow-deployer.sh
+++ b/prow/setup-prow-deployer.sh
@@ -9,12 +9,12 @@ TARGET_FOLDER="/tmp"
 
 create_service_account() {
     echo -e "\\nCreating a service account in ${NAMESPACE} namespace: ${SERVICE_ACCOUNT_NAME}"
-    kubectl create sa "${SERVICE_ACCOUNT_NAME}" --namespace "${NAMESPACE}"
+    kubectl create sa "${SERVICE_ACCOUNT_NAME}" --namespace "${NAMESPACE}" || echo Skipping
 }
 
 get_secret_name_from_service_account() {
     echo -e "\\nGetting secret of service account ${SERVICE_ACCOUNT_NAME} on ${NAMESPACE}"
-    SECRET_NAME=$(kubectl get sa "${SERVICE_ACCOUNT_NAME}" --namespace="${NAMESPACE}" -o json | jq -r .secrets[].name)
+    SECRET_NAME=$(kubectl get sa "${SERVICE_ACCOUNT_NAME}" --namespace="${NAMESPACE}" -o json | jq -r .secrets[].name | grep token)
     echo "Secret name: ${SECRET_NAME}"
 }
 

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -9,8 +9,8 @@ set -ex
 sh gen-config.sh
 
 # update config and plugins
-kubectl create configmap config --from-file=config.yaml=config.gen.yaml --dry-run -o yaml | kubectl replace configmap -n default config -f -
-kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap -n default plugins -f -
+kubectl -n default create configmap config --from-file=config.yaml=config.gen.yaml --dry-run -o yaml | kubectl -n default replace configmap config -f -
+kubectl -n default create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl -n default replace configmap plugins -f -
 
 # update deployments etc.
 for file in `ls cluster`; do
@@ -19,5 +19,5 @@ done
 
 # restart deployments
 for deployment in `kubectl get deployments -n default -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'`; do
-  kubectl rollout restart deployment $deployment
+  kubectl -n default rollout restart deployment $deployment
 done


### PR DESCRIPTION
- Update instructions for GitHub hook
- Explicitly use `-n default` where applicable to avoid installing in other namespace
- Fix ServiceAccount retrieval on OpenShift
- Give it some time for the cert-manager deployment to succeed