### PR TITLE
Update dockerfile to use exect hugo version

### DIFF
--- a/docker/maistra-builder_1.2.Dockerfile
+++ b/docker/maistra-builder_1.2.Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sfL https://download.docker.com/linux/fedora/docker-ce.repo -o /etc/yu
     dnf -y update && \
     dnf -y install fedpkg copr-cli jq xz unzip hostname golang \
                    make automake gcc gcc-c++ git ShellCheck which \
-                   hugo rubygem-asciidoctor rubygem-html-proofer docker-ce && \
+                   rubygem-asciidoctor rubygem-html-proofer docker-ce && \
     dnf -y clean all
 
 
@@ -35,7 +35,7 @@ RUN GO111MODULE=off go get github.com/myitcv/gobin && \
 RUN curl https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz linux-amd64/helm --strip=1 && mv helm /usr/local/bin
 
 # Hugo
-RUN curl https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar -xz && mv hugo /usr/local/bin
+RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar -xz hugo && mv hugo /usr/local/bin
 
 
 # Kubectl

--- a/docker/maistra-builder_1.2.Dockerfile
+++ b/docker/maistra-builder_1.2.Dockerfile
@@ -6,6 +6,9 @@ ENV KUBECTL_VERSION="v1.17.0"
 ENV HELM_VERSION="v2.16.6"
 ENV VALE_VERSION="v2.1.1"
 
+#this needs to match the version of Hugo used in Maistra.io's netlify.toml file
+ENV HUGO_VERSION="0.69.2"
+
 # Set CI variable which can be checked by test scripts to verify
 # if running in the continuous integration environment.
 ENV CI prow
@@ -30,6 +33,10 @@ RUN GO111MODULE=off go get github.com/myitcv/gobin && \
 
 # Helm
 RUN curl https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz linux-amd64/helm --strip=1 && mv helm /usr/local/bin
+
+# Hugo
+RUN curl https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar -xz && mv hugo /usr/local/bin
+
 
 # Kubectl
 RUN curl -sfL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \


### PR DESCRIPTION
We were using different version of Hugo for building the website, testing the website, and for local development. We should tie the three versions together such that we're testing what we deploy. This uses the version from Fedora 32 and ties it down to a specific release.