### PR TITLE
Rename unit test job for maistra-1.2 branch

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -354,14 +354,16 @@ presubmits:
         securityContext:
           privileged: true
   Maistra/istio:
-  - name: unittests
+  - name: maistra-istio-1.2-unit
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
     branches:
-      - maistra-1.2
       - maistra-1.2-future
+    context: ci/prow/unit
+    rerun_command: /test unit
     spec:
       containers:
       - image: "quay.io/maistra/maistra-builder:1.2"

--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -369,9 +369,14 @@ presubmits:
       - image: "quay.io/maistra/maistra-builder:1.2"
         command:
         - make
-        - init
-        - test
+        - -e
+        - T=-v
+        - build
+        - racetest
+        - binaries-test
         env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: GOFLAGS
           value: -mod=vendor
         - name: XDG_CACHE_HOME

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -116,14 +116,16 @@ presubmits:
         securityContext:
           privileged: true
   Maistra/istio:
-  - name: unittests
+  - name: maistra-istio-1.2-unit
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
     branches:
-      - maistra-1.2
       - maistra-1.2-future
+    context: ci/prow/unit
+    rerun_command: /test unit
     spec:
       containers:
       - image: "quay.io/maistra/maistra-builder:1.2"

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -131,9 +131,14 @@ presubmits:
       - image: "quay.io/maistra/maistra-builder:1.2"
         command:
         - make
-        - init
-        - test
+        - -e
+        - T=-v
+        - build
+        - racetest
+        - binaries-test
         env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
         - name: GOFLAGS
           value: -mod=vendor
         - name: XDG_CACHE_HOME


### PR DESCRIPTION
Renaming the new unit tests job, and setting the `context` and `rerun_commands` in the config.