### PR TITLE
Speed up build-containers job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ lint:
 
 # this will build the containers and then try to use them to build themselves again, making sure we didn't break docker support
 build-containers: maistra-builder
-	docker run --privileged -v ${PWD}:/work --workdir /work ${HUB}/maistra-builder:1.1 make maistra-builder
-	docker run --privileged -v ${PWD}:/work --workdir /work ${HUB}/maistra-builder:1.2 make maistra-builder
+	docker run --privileged -v ${PWD}:/work --workdir /work ${HUB}/maistra-builder:1.1 make maistra-builder_1.2
+	docker run --privileged -v ${PWD}:/work --workdir /work ${HUB}/maistra-builder:1.2 make maistra-builder_1.2


### PR DESCRIPTION
This will now only build one container to test the docker setup. Should be enough to prove that docker-in-docker still works.