### PR TITLE
enable verbosity for unittest

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -434,6 +434,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - make
+        - -e
+        - T=-v
         - init
         - test
         env:

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -194,6 +194,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - make
+        - -e
+        - T=-v
         - init
         - test
         env:


### PR DESCRIPTION
so we can transform the log to a junit format.