### PR TITLE
fix maistra org rename fallout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Test Infrastructure
 
-This repository is meant to hold all information required to deploy and run Maistra test infrastructure in an Infrastructe-as-Code fashion.
+This repository is meant to hold all information required to deploy and run maistra test infrastructure in an Infrastructe-as-Code fashion.
 
 ## Build Container
 
 The build container (`maistra-builder`) is used by Prow to run unit tests and the linters against [`maistra/istio`](https://github.com/maistra/istio). 
 
-To build the `maistra-builder` container image locally, run `make maistra-builder` in this repository. It will build all available versions of the container; generally, one per Maistra minor version: 1.0, 1.1, etc.
+To build the `maistra-builder` container image locally, run `make maistra-builder` in this repository. It will build all available versions of the container; generally, one per maistra minor version: 1.0, 1.1, etc.
 
 ## Using Prow
 
-The official Maistra Prow instance is available at https://prow.maistra.io. All commits to this repository's `main` branch will be auto-applied to that cluster.
+The official maistra Prow instance is available at https://prow.maistra.io. All commits to this repository's `main` branch will be auto-applied to that cluster.
 
 ### Prow Configuration
 
@@ -23,7 +23,7 @@ All jobs are located in the files `prow/config/presubmits.yaml` and `prow/config
 ```yaml
 presubmits:
   # the <github org>/<repository> this job is run against
-  Maistra/istio:
+  maistra/istio:
     # the job's name
   - name: unittests
     # `decorate` determines whether to wrap the container image using prow's init containers.

--- a/docker/maistra-builder_1.2.Dockerfile
+++ b/docker/maistra-builder_1.2.Dockerfile
@@ -7,7 +7,7 @@ ENV HELM_VERSION="v2.16.6"
 ENV VALE_VERSION="v2.1.1"
 ENV KIND_VERSION="v0.7.0"
 
-#this needs to match the version of Hugo used in Maistra.io's netlify.toml file
+#this needs to match the version of Hugo used in maistra.io's netlify.toml file
 ENV HUGO_VERSION="0.69.2"
 
 # Set CI variable which can be checked by test scripts to verify

--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -12,7 +12,7 @@ branch-protection:
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: false
-    Maistra:
+    maistra:
       required_pull_request_reviews:
         required_approving_review_count: 2
         require_code_owner_reviews: false
@@ -52,7 +52,7 @@ plank:
         bucket: "maistra-prow-testing"
       gcs_credentials_secret: "gcs-credentials"
 postsubmits:
-  Maistra/test-infra:
+  maistra/test-infra:
   - name: test-infra_deploy-prow
     decorate: true
     skip_report: false
@@ -91,7 +91,7 @@ postsubmits:
         securityContext:
           privileged: true
 
-  Maistra/ior:
+  maistra/ior:
   - name: ior_update-rpm
     decorate: true
     path_alias: maistra.io/ior
@@ -121,7 +121,7 @@ postsubmits:
         - -l auto-merge
         - -m bump-rpm
 
-  Maistra/istio-operator:
+  maistra/istio-operator:
   - name: istio-operator_update-rpm
     decorate: true
     path_alias: maistra.io/istio-operator
@@ -151,7 +151,7 @@ postsubmits:
         - -l auto-merge
         - -m bump-rpm
 
-  Maistra/rpm-common:
+  maistra/rpm-common:
   - name: rpm-common_update
     decorate: true
     path_alias: maistra.io/rpm-common
@@ -239,7 +239,7 @@ presets:
     secret:
       secretName: copr
 presubmits:
-  Maistra/maistra.github.io:
+  maistra/maistra.github.io:
   - name: maistra.github.io_lint
     decorate: true
     always_run: true
@@ -272,7 +272,7 @@ presubmits:
         - check-links
     trigger: "(?m)^/test check-links"
     rerun_command: "/test check-links"
-  Maistra/istio-operator:
+  maistra/istio-operator:
   - name: istio-operator_unittests
     decorate: true
     always_run: true
@@ -342,7 +342,7 @@ presubmits:
           value: /tmp/cache
         - name: GOCACHE
           value: /tmp/cache
-  Maistra/test-infra:
+  maistra/test-infra:
   - name: test-infra_lint
     decorate: true
     always_run: true
@@ -390,7 +390,7 @@ presubmits:
         securityContext:
           privileged: true
 
-  Maistra/istio:
+  maistra/istio:
   - name: istio_1.2-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
@@ -526,7 +526,7 @@ presubmits:
           type: Directory
         name: cgroup
 
-  Maistra/rpm-common:
+  maistra/rpm-common:
   - name: rpm-common_tests
     decorate: true
     always_run: true
@@ -544,7 +544,7 @@ presubmits:
         - make
         - test
 
-  Maistra/rpm-ior:
+  maistra/rpm-ior:
   - name: rpm-ior_tests
     decorate: true
     always_run: true
@@ -564,7 +564,7 @@ presubmits:
         - make
         - test
 
-  Maistra/rpm-istio-operator:
+  maistra/rpm-istio-operator:
   - name: rpm-istio-operator_tests
     decorate: true
     always_run: true
@@ -703,16 +703,16 @@ github_reporter:
 
 tide:
   merge_method:
-    Maistra: squash
+    maistra: squash
   target_url: https://prow.maistra.io/tide
 
   queries:
 
   - repos:
-    - Maistra/rpm-common
-    - Maistra/rpm-ior
-    - Maistra/rpm-istio-operator
-    - Maistra/test-infra
+    - maistra/rpm-common
+    - maistra/rpm-ior
+    - maistra/rpm-istio-operator
+    - maistra/test-infra
     labels:
     - "okay to merge"
     missingLabels:
@@ -722,8 +722,8 @@ tide:
     reviewApprovedRequired: true
 
   - repos:
-    - Maistra/rpm-ior
-    - Maistra/rpm-istio-operator
+    - maistra/rpm-ior
+    - maistra/rpm-istio-operator
     author: maistra-bot
     missingLabels:
     - do-not-merge

--- a/prow/config/branch-protection.yaml
+++ b/prow/config/branch-protection.yaml
@@ -6,7 +6,7 @@ branch-protection:
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: false
-    Maistra:
+    maistra:
       required_pull_request_reviews:
         required_approving_review_count: 2
         require_code_owner_reviews: false

--- a/prow/config/postsubmits.yaml
+++ b/prow/config/postsubmits.yaml
@@ -1,5 +1,5 @@
 postsubmits:
-  Maistra/test-infra:
+  maistra/test-infra:
   - name: test-infra_deploy-prow
     decorate: true
     skip_report: false
@@ -38,7 +38,7 @@ postsubmits:
         securityContext:
           privileged: true
 
-  Maistra/ior:
+  maistra/ior:
   - name: ior_update-rpm
     decorate: true
     path_alias: maistra.io/ior
@@ -68,7 +68,7 @@ postsubmits:
         - -l auto-merge
         - -m bump-rpm
 
-  Maistra/istio-operator:
+  maistra/istio-operator:
   - name: istio-operator_update-rpm
     decorate: true
     path_alias: maistra.io/istio-operator
@@ -98,7 +98,7 @@ postsubmits:
         - -l auto-merge
         - -m bump-rpm
 
-  Maistra/rpm-common:
+  maistra/rpm-common:
   - name: rpm-common_update
     decorate: true
     path_alias: maistra.io/rpm-common

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  Maistra/maistra.github.io:
+  maistra/maistra.github.io:
   - name: maistra.github.io_lint
     decorate: true
     always_run: true
@@ -32,7 +32,7 @@ presubmits:
         - check-links
     trigger: "(?m)^/test check-links"
     rerun_command: "/test check-links"
-  Maistra/istio-operator:
+  maistra/istio-operator:
   - name: istio-operator_unittests
     decorate: true
     always_run: true
@@ -102,7 +102,7 @@ presubmits:
           value: /tmp/cache
         - name: GOCACHE
           value: /tmp/cache
-  Maistra/test-infra:
+  maistra/test-infra:
   - name: test-infra_lint
     decorate: true
     always_run: true
@@ -150,7 +150,7 @@ presubmits:
         securityContext:
           privileged: true
 
-  Maistra/istio:
+  maistra/istio:
   - name: istio_1.2-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
@@ -286,7 +286,7 @@ presubmits:
           type: Directory
         name: cgroup
 
-  Maistra/rpm-common:
+  maistra/rpm-common:
   - name: rpm-common_tests
     decorate: true
     always_run: true
@@ -304,7 +304,7 @@ presubmits:
         - make
         - test
 
-  Maistra/rpm-ior:
+  maistra/rpm-ior:
   - name: rpm-ior_tests
     decorate: true
     always_run: true
@@ -324,7 +324,7 @@ presubmits:
         - make
         - test
 
-  Maistra/rpm-istio-operator:
+  maistra/rpm-istio-operator:
   - name: rpm-istio-operator_tests
     decorate: true
     always_run: true

--- a/prow/config/tide.yaml
+++ b/prow/config/tide.yaml
@@ -5,16 +5,16 @@ github_reporter:
 
 tide:
   merge_method:
-    Maistra: squash
+    maistra: squash
   target_url: https://prow.maistra.io/tide
 
   queries:
 
   - repos:
-    - Maistra/rpm-common
-    - Maistra/rpm-ior
-    - Maistra/rpm-istio-operator
-    - Maistra/test-infra
+    - maistra/rpm-common
+    - maistra/rpm-ior
+    - maistra/rpm-istio-operator
+    - maistra/test-infra
     labels:
     - "okay to merge"
     missingLabels:
@@ -24,8 +24,8 @@ tide:
     reviewApprovedRequired: true
 
   - repos:
-    - Maistra/rpm-ior
-    - Maistra/rpm-istio-operator
+    - maistra/rpm-ior
+    - maistra/rpm-istio-operator
     author: maistra-bot
     missingLabels:
     - do-not-merge

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -1,5 +1,5 @@
 plugins:
-  Maistra/maistra.github.io:
+  maistra/maistra.github.io:
   - size
   - trigger
   - lgtm
@@ -10,39 +10,39 @@ plugins:
   - lgtm
   - hold
   - wip
-  Maistra/istio-operator:
+  maistra/istio-operator:
   - size
   - trigger
   - lgtm
   - hold
   - wip
-  Maistra/test-infra:
+  maistra/test-infra:
   - size
   - trigger
   - hold
   - wip
-  Maistra/istio:
+  maistra/istio:
   - size
   - trigger
   - lgtm
   - hold
   - wip
-  Maistra/ior:
+  maistra/ior:
   - size
   - trigger
   - hold
   - wip
-  Maistra/rpm-common:
+  maistra/rpm-common:
   - size
   - trigger
   - hold
   - wip
-  Maistra/rpm-ior:
+  maistra/rpm-ior:
   - size
   - trigger
   - hold
   - wip
-  Maistra/rpm-istio-operator:
+  maistra/rpm-istio-operator:
   - size
   - trigger
   - hold
@@ -50,7 +50,7 @@ plugins:
 
 
 external_plugins:
-  Maistra:
+  maistra:
   - name: cherrypicker
     events:
       - issue_comment


### PR DESCRIPTION
This is already live (otherwise the jobs wouldn't run and it would never be applied)