### PR TITLE
Move 1.2 jobs to 2.0 branch

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -391,14 +391,14 @@ presubmits:
           privileged: true
 
   maistra/istio:
-  - name: istio_1.2-unit
+  - name: istio_2.0-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
     branches:
-      - maistra-1.2-future
+      - maistra-2.0
     rerun_command: /test unit
     spec:
       containers:
@@ -421,12 +421,14 @@ presubmits:
         - name: GOCACHE
           value: /tmp/cache
 
-  - name: istio_1.2-integration
+  - name: istio_2.0-integration
+    trigger: (?m)^/test( | .* )integration,?($|\s.*)
+    rerun_command: /test integration
     skip_report: false
     max_concurrency: 1
     always_run: true
     branches:
-    - maistra-1.2
+    - maistra-2.0
     decorate: true
     path_alias: istio.io/istio
     spec:

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -151,14 +151,14 @@ presubmits:
           privileged: true
 
   maistra/istio:
-  - name: istio_1.2-unit
+  - name: istio_2.0-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
     branches:
-      - maistra-1.2-future
+      - maistra-2.0
     rerun_command: /test unit
     spec:
       containers:
@@ -181,12 +181,14 @@ presubmits:
         - name: GOCACHE
           value: /tmp/cache
 
-  - name: istio_1.2-integration
+  - name: istio_2.0-integration
+    trigger: (?m)^/test( | .* )integration,?($|\s.*)
+    rerun_command: /test integration
     skip_report: false
     max_concurrency: 1
     always_run: true
     branches:
-    - maistra-1.2
+    - maistra-2.0
     decorate: true
     path_alias: istio.io/istio
     spec:


### PR DESCRIPTION
The 1.2 release is going to be 2.0 now, so the branch name has changed.