### PR TITLE
Use official bazel binary

### DIFF
--- a/docker/maistra-proxy-builder_2.0.Dockerfile
+++ b/docker/maistra-proxy-builder_2.0.Dockerfile
@@ -3,16 +3,18 @@ FROM centos:8
 # Versions
 ENV K8S_TEST_INFRA_VERSION=41512c7491a99c6bdf330e1a76d45c8a10d3679b
 
-RUN curl -o /etc/yum.repos.d/bazel.repo -Ls https://copr.fedorainfracloud.org/coprs/g/maistra/bazel.el8-1.2/repo/epel-8/group_maistra-bazel.el8-1.2-epel-8.repo
-
 RUN dnf -y upgrade --refresh && \
     dnf -y install dnf-plugins-core https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y config-manager --set-enabled PowerTools && \
     dnf -y install git make libtool patch libatomic which \
                    autoconf automake libtool cmake python3 \
                    gcc gcc-c++ ninja-build golang annobin \
-                   java-11-openjdk-devel bazel jq && \
+                   java-11-openjdk-devel jq && \
     dnf -y clean all
+
+# Bazel
+RUN curl -o /usr/bin/bazel -Ls https://github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-linux-x86_64 && \
+    chmod +x /usr/bin/bazel
 
 # Go tools
 ENV GOBIN=/usr/local/bin


### PR DESCRIPTION
Current one reports its version as `2.2.0- (@non-git)` where it's
expected to be just `2.2.0`.

Example: https://github.com/maistra/proxy/pull/45/files