### PR TITLE
Add max_concurreny options to jobs with high resource usage

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -428,7 +428,7 @@ presubmits:
     run_if_changed: '^docker/maistra-builder_.*\.Dockerfile|^docker/scripts'
     branches:
       - main
-    max_concurrency: 1
+    max_concurrency: 2
     spec:
       containers:
       - image: "quay.io/maistra-dev/maistra-builder:1.2"
@@ -446,7 +446,7 @@ presubmits:
     run_if_changed: '^docker/maistra-proxy-builder_.*\.Dockerfile'
     branches:
       - main
-    max_concurrency: 1
+    max_concurrency: 2
     spec:
       containers:
       - image: "quay.io/maistra-dev/maistra-builder:1.2"
@@ -465,6 +465,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/proxy
     skip_report: false
+    max_concurrency: 1
     branches:
       - maistra-2.0
       - jwendell/ci
@@ -483,6 +484,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
+    max_concurrency: 2
     branches:
       - maistra-2.0
     rerun_command: /test unit
@@ -513,6 +515,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
+    max_concurrency: 2
     branches:
       - maistra-2.0
     rerun_command: /test lint
@@ -539,6 +542,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
+    max_concurrency: 2
     branches:
       - maistra-2.0
     rerun_command: /test gencheck
@@ -564,7 +568,7 @@ presubmits:
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
     rerun_command: /test integration
     skip_report: false
-    max_concurrency: 1
+    max_concurrency: 2
     always_run: true
     branches:
     - maistra-2.0
@@ -629,7 +633,7 @@ presubmits:
 
   - name: istio_1.1-integration
     skip_report: false
-    max_concurrency: 1
+    max_concurrency: 2
     always_run: true
     branches:
     - maistra-1.1

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -138,7 +138,7 @@ presubmits:
     run_if_changed: '^docker/maistra-builder_.*\.Dockerfile|^docker/scripts'
     branches:
       - main
-    max_concurrency: 1
+    max_concurrency: 2
     spec:
       containers:
       - image: "quay.io/maistra-dev/maistra-builder:1.2"
@@ -156,7 +156,7 @@ presubmits:
     run_if_changed: '^docker/maistra-proxy-builder_.*\.Dockerfile'
     branches:
       - main
-    max_concurrency: 1
+    max_concurrency: 2
     spec:
       containers:
       - image: "quay.io/maistra-dev/maistra-builder:1.2"
@@ -175,6 +175,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/proxy
     skip_report: false
+    max_concurrency: 1
     branches:
       - maistra-2.0
       - jwendell/ci
@@ -193,6 +194,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
+    max_concurrency: 2
     branches:
       - maistra-2.0
     rerun_command: /test unit
@@ -223,6 +225,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
+    max_concurrency: 2
     branches:
       - maistra-2.0
     rerun_command: /test lint
@@ -249,6 +252,7 @@ presubmits:
     always_run: true
     path_alias: istio.io/istio
     skip_report: false
+    max_concurrency: 2
     branches:
       - maistra-2.0
     rerun_command: /test gencheck
@@ -274,7 +278,7 @@ presubmits:
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
     rerun_command: /test integration
     skip_report: false
-    max_concurrency: 1
+    max_concurrency: 2
     always_run: true
     branches:
     - maistra-2.0
@@ -339,7 +343,7 @@ presubmits:
 
   - name: istio_1.1-integration
     skip_report: false
-    max_concurrency: 1
+    max_concurrency: 2
     always_run: true
     branches:
     - maistra-1.1


### PR DESCRIPTION
Also updates some max_concurreny values to `2` (because we have two workers now)