### PR TITLE
Install both yqv2 and yqv3

### DIFF
--- a/docker/maistra-builder_1.1.Dockerfile
+++ b/docker/maistra-builder_1.1.Dockerfile
@@ -18,6 +18,7 @@ RUN chmod -R +x /tmp/scripts/ && \
 # Set CI variable which can be checked by test scripts to verify
 # if running in the continuous integration environment.
 ENV CI prow
+ENV PATH /root/go/bin:${PATH}
 
 ADD scripts/entrypoint.sh /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint

--- a/docker/scripts/install_base.sh
+++ b/docker/scripts/install_base.sh
@@ -6,4 +6,7 @@ set -ex
 
 dnf install -y xz unzip hostname \
                make automake gcc gcc-c++ git diffutils \
-               which
+               which jq python3-pip
+
+#install yqv2 for istio-operator
+pip3 install yq

--- a/docker/scripts/install_docs_tools.sh
+++ b/docker/scripts/install_docs_tools.sh
@@ -2,7 +2,6 @@
 set -ex
 
 HUGO_VERSION=0.46
-export GOBIN=/usr/local/bin
 
 curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz \
  --OUTPUT /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz

--- a/docker/scripts/install_go_13.sh
+++ b/docker/scripts/install_go_13.sh
@@ -8,5 +8,6 @@ curl https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz | tar -xz -C /usr/loca
 
 go version
 
-export GOBIN=/usr/local/bin
+export GOPATH=/root/go
+
 go get github.com/jstemmer/go-junit-report


### PR DESCRIPTION
This will default to yqv3, but also install yqv2 in another directory. This is required for MAISTRA-1885 (https://github.com/maistra/istio-operator/pull/573)