### PR TITLE
Update shellcheck

### DIFF
--- a/docker/maistra-builder_1.1.Dockerfile
+++ b/docker/maistra-builder_1.1.Dockerfile
@@ -26,3 +26,4 @@ RUN dnf clean all && dnf update -y
 
 VOLUME /var/lib/docker
 ENTRYPOINT ["entrypoint"]
+

--- a/docker/maistra-builder_1.2.Dockerfile
+++ b/docker/maistra-builder_1.2.Dockerfile
@@ -58,3 +58,4 @@ ENV HOME /work
 
 VOLUME /var/lib/docker
 ENTRYPOINT ["entrypoint"]
+

--- a/docker/scripts/install_shellcheck.sh
+++ b/docker/scripts/install_shellcheck.sh
@@ -6,6 +6,6 @@ set -ex
 
 export SHELLCHECK_VERSION=v0.7.0
 
-curl https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz | tar -xJ -C /tmp
+curl -L https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz | tar -xJv -C /tmp
 
 mv /tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck


### PR DESCRIPTION
Our shellcheck broke this weekend as follows: 

```
./tools/runLinter.sh
+ find . -name '*.sh' -print0
+ xargs -0 -r shellcheck
You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(
make: *** [Makefile:17: lint] Error 123
```

The changes for 1.1 update the URL. For 2.0, we're depending on the package. Doing some testing locally, I *think* all we need to do for 2.0 is trigger a rebuild of the containers. 