### PR TITLE
MAISTRA-1977: Setup a volume to store a cache for bazel builds

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -207,6 +207,16 @@ postsubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
 
   - name: proxy_2.0-update-istio
     decorate: true
@@ -721,6 +731,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
   - name: proxy_1.1-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
@@ -746,6 +766,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
 
   maistra/envoy:
   - name: envoy_1.1-unit
@@ -774,6 +804,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
   - name: envoy_2.0-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
@@ -799,6 +839,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
 
   maistra/istio:
   - name: istio_2.0-unit

--- a/prow/config/postsubmits.yaml
+++ b/prow/config/postsubmits.yaml
@@ -144,6 +144,16 @@ postsubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
 
   - name: proxy_2.0-update-istio
     decorate: true

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -258,6 +258,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
   - name: proxy_1.1-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
@@ -283,6 +293,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
 
   maistra/envoy:
   - name: envoy_1.1-unit
@@ -311,6 +331,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
   - name: envoy_2.0-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)
     decorate: true
@@ -336,6 +366,16 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+        volumeMounts:
+        - name: bazel-cache
+          mountPath: /bazel-cache
+        securityContext:
+          privileged: true
+      volumes:
+      - name: bazel-cache
+        hostPath:
+          path: /mnt/bazel-cache
+          type: DirectoryOrCreate
 
   maistra/istio:
   - name: istio_2.0-unit


### PR DESCRIPTION
The CI scripts running on those pods will be updated to use the
directory `/bazel-cache` as a cache dir.