### PR TITLE
fix(ns): makes namespaces customizable

### DIFF
--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: cherrypicker
   labels:
     app.kubernetes.io/part-of: prow

--- a/prow/cluster/cherrypicker_service.yaml
+++ b/prow/cluster/cherrypicker_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: prow
     app: cherrypicker
-  namespace: default
+  namespace: ${NAMESPACE}
   name: cherrypicker
 spec:
   selector:

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crier
-  namespace: default
+  namespace: ${NAMESPACE}
   labels:
     app: crier
 spec:

--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: "crier"
-  namespace: "default"
+  namespace: ${NAMESPACE}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -39,7 +39,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: "crier"
-  namespace: "default"
+  namespace: ${NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -47,4 +47,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "crier"
-  namespace: "default"
+  namespace: ${NAMESPACE}

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: deck
   labels:
     app: deck

--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "deck"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "deck"
 rules:
   - apiGroups:
@@ -23,7 +23,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
+  namespace: ${WORKER_NS}
   name: "deck"
 rules:
   - apiGroups:
@@ -36,7 +36,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "deck"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49,7 +49,7 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
+  namespace: ${WORKER_NS}
   name: "deck"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58,4 +58,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "deck"
-  namespace: default
+  namespace: ${NAMESPACE}

--- a/prow/cluster/deck_service.yaml
+++ b/prow/cluster/deck_service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: deck
-  namespace: default
+  namespace: ${NAMESPACE}
   name: deck
 spec:
   selector:

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: hook
   labels:
     app: hook

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=https://api.github.com
         - --config-path=/etc/config/config.yaml
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "hook"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "hook"
 rules:
   - apiGroups:
@@ -29,7 +29,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "hook"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/hook_service.yaml
+++ b/prow/cluster/hook_service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: hook
-  namespace: default
+  namespace: ${NAMESPACE}
   name: hook
 spec:
   selector:

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: horologium
   labels:
     app: horologium

--- a/prow/cluster/horologium_rbac.yaml
+++ b/prow/cluster/horologium_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "horologium"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "horologium"
 rules:
   - apiGroups:
@@ -21,7 +21,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "horologium"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/ingress.yaml
+++ b/prow/cluster/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: ing
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: plank
   labels:
     app: plank

--- a/prow/cluster/plank_rbac.yaml
+++ b/prow/cluster/plank_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "plank"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "plank"
 rules:
   - apiGroups:
@@ -24,7 +24,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
+  namespace: ${WORKER_NS}
   name: "plank"
 rules:
   - apiGroups:
@@ -39,7 +39,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "plank"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52,7 +52,7 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
+  namespace: ${WORKER_NS}
   name: "plank"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -61,4 +61,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "plank"
-  namespace: default
+  namespace: ${NAMESPACE}

--- a/prow/cluster/plank_service.yaml
+++ b/prow/cluster/plank_service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: plank
-  namespace: default
+  namespace: ${NAMESPACE}
   name: plank
 spec:
   ports:

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: sinker
   labels:
     app: sinker

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "sinker"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "sinker"
 rules:
   - apiGroups:
@@ -39,7 +39,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
+  namespace: ${WORKER_NS}
   name: "sinker"
 rules:
   - apiGroups:
@@ -53,7 +53,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "sinker"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -66,7 +66,7 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
+  namespace: ${WORKER_NS}
   name: "sinker"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -75,4 +75,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "sinker"
-  namespace: default
+  namespace: ${NAMESPACE}

--- a/prow/cluster/sinker_service.yaml
+++ b/prow/cluster/sinker_service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: sinker
-  namespace: default
+  namespace: ${NAMESPACE}
   name: sinker
 spec:
   ports:

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: statusreconciler
   labels:
     app: statusreconciler

--- a/prow/cluster/statusreconciler_rbac.yaml
+++ b/prow/cluster/statusreconciler_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "statusreconciler"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "statusreconciler"
 rules:
   - apiGroups:
@@ -20,7 +20,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "statusreconciler"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: tide
   labels:
     app: tide

--- a/prow/cluster/tide_rbac.yaml
+++ b/prow/cluster/tide_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "tide"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "tide"
 rules:
   - apiGroups:
@@ -23,7 +23,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: default
+  namespace: ${NAMESPACE}
   name: "tide"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/cluster/tide_service.yaml
+++ b/prow/cluster/tide_service.yaml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   labels:
     app: tide
-  namespace: default
+  namespace: ${NAMESPACE}
   name: tide
 spec:
   selector:

--- a/prow/config/prow.yaml
+++ b/prow/config/prow.yaml
@@ -1,2 +1,2 @@
-prowjob_namespace: default
-pod_namespace: test-pods
+prowjob_namespace: ${NAMESPACE}
+pod_namespace: ${WORKER_NS}

--- a/prow/create.sh
+++ b/prow/create.sh
@@ -2,22 +2,25 @@
 
 set -ex
 
+NAMESPACE=${NAMESPACE:-default}
+WORKER_NS=${WORKER_NS:-test-pods}
+
 # create test-pods namespace
-kubectl create namespace test-pods || echo Skipping
+kubectl create "${NAMESPACE}" test-pods || echo Skipping
 
 # create configmaps
-kubectl -n default create cm config || echo Skipping
-kubectl -n default create cm plugins || echo Skipping
+kubectl -n "${NAMESPACE}" create cm config || echo Skipping
+kubectl -n "${NAMESPACE}" create cm plugins || echo Skipping
 
 # create secrets
-kubectl -n default create secret generic hmac-token --from-file=hmac=secrets/github-hmac-secret
-kubectl -n default create secret generic cookie --from-file=secret=secrets/cookie-secret
-kubectl -n default create secret generic oauth-token --from-file=oauth=secrets/github-token
+kubectl -n "${NAMESPACE}" create secret generic hmac-token --from-file=hmac=secrets/github-hmac-secret
+kubectl -n "${NAMESPACE}" create secret generic cookie --from-file=secret=secrets/cookie-secret
+kubectl -n "${NAMESPACE}" create secret generic oauth-token --from-file=oauth=secrets/github-token
 
-kubectl -n test-pods create secret generic github-token --from-file=github-token=secrets/github-token || echo Skipping
-kubectl -n test-pods create secret generic gcs-credentials --from-file=service-account.json=secrets/gcs-credentials.json || echo Skipping
-kubectl -n test-pods create secret generic quay-pusher-dockercfg --from-file=config.json=secrets/maistra-dev-prow-auth.json || echo Skipping
-kubectl -n test-pods create secret generic copr --from-file=copr=secrets/copr-token-bot || echo Skipping
+kubectl -n "${WORKER_NS}" create secret generic github-token --from-file=github-token=secrets/github-token || echo Skipping
+kubectl -n "${WORKER_NS}" create secret generic gcs-credentials --from-file=service-account.json=secrets/gcs-credentials.json || echo Skipping
+kubectl -n "${WORKER_NS}" create secret generic quay-pusher-dockercfg --from-file=config.json=secrets/maistra-dev-prow-auth.json || echo Skipping
+kubectl -n "${WORKER_NS}" create secret generic copr --from-file=copr=secrets/copr-token-bot || echo Skipping
 
 # create service account including secret holding kubeconfig (for auto-updating prow config on merged PRs)
 ./setup-prow-deployer.sh

--- a/prow/create.sh
+++ b/prow/create.sh
@@ -13,9 +13,9 @@ kubectl -n "${NAMESPACE}" create cm config || echo Skipping
 kubectl -n "${NAMESPACE}" create cm plugins || echo Skipping
 
 # create secrets
-kubectl -n "${NAMESPACE}" create secret generic hmac-token --from-file=hmac=secrets/github-hmac-secret
-kubectl -n "${NAMESPACE}" create secret generic cookie --from-file=secret=secrets/cookie-secret
-kubectl -n "${NAMESPACE}" create secret generic oauth-token --from-file=oauth=secrets/github-token
+kubectl -n "${NAMESPACE}" create secret generic hmac-token --from-file=hmac=secrets/github-hmac-secret || echo Skipping
+kubectl -n "${NAMESPACE}" create secret generic cookie --from-file=secret=secrets/cookie-secret || echo Skipping
+kubectl -n "${NAMESPACE}" create secret generic oauth-token --from-file=oauth=secrets/github-token || echo Skipping
 
 kubectl -n "${WORKER_NS}" create secret generic github-token --from-file=github-token=secrets/github-token || echo Skipping
 kubectl -n "${WORKER_NS}" create secret generic gcs-credentials --from-file=service-account.json=secrets/gcs-credentials.json || echo Skipping

--- a/prow/create.sh
+++ b/prow/create.sh
@@ -6,7 +6,7 @@ NAMESPACE=${NAMESPACE:-default}
 WORKER_NS=${WORKER_NS:-test-pods}
 
 # create test-pods namespace
-kubectl create "${NAMESPACE}" test-pods || echo Skipping
+kubectl create namespace "${WORKER_NS}" || echo Skipping
 
 # create configmaps
 kubectl -n "${NAMESPACE}" create cm config || echo Skipping

--- a/prow/gen-config.sh
+++ b/prow/gen-config.sh
@@ -15,6 +15,7 @@ echo "#======================================
 #    Run gen-config.sh to regenerate.
 #======================================" > config.gen.yaml
 
-for file in ${DIR}/config/*; do
-  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "${file}" >> ${DIR}/config.gen.yaml
+for file in "${DIR}"/config/*; do
+  # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be replaced
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "${file}" >> "${DIR}"/config.gen.yaml
 done

--- a/prow/gen-config.sh
+++ b/prow/gen-config.sh
@@ -17,5 +17,5 @@ echo "#======================================
 
 for file in "${DIR}"/config/*; do
   # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be expanded
-  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "${file}" >> "${DIR}"/config.gen.yaml
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@g' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@g' "${file}" >> "${DIR}"/config.gen.yaml
 done

--- a/prow/gen-config.sh
+++ b/prow/gen-config.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAMESPACE=${NAMESPACE:-default}
+WORKER_NS=${WORKER_NS:-test-pods}
+
 # re-generate config
 echo "#======================================
 # This configuration is auto-generated. 
@@ -10,6 +15,6 @@ echo "#======================================
 #    Run gen-config.sh to regenerate.
 #======================================" > config.gen.yaml
 
-for file in config/*; do
-  cat "${file}" >> config.gen.yaml
+for file in ${DIR}/config/*; do
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "${file}" >> ${DIR}/config.gen.yaml
 done

--- a/prow/gen-config.sh
+++ b/prow/gen-config.sh
@@ -16,6 +16,6 @@ echo "#======================================
 #======================================" > config.gen.yaml
 
 for file in "${DIR}"/config/*; do
-  # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be replaced
+  # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be expanded
   sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "${file}" >> "${DIR}"/config.gen.yaml
 done

--- a/prow/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/prow/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -3,12 +3,12 @@ controller:
   service:
     type: ClusterIP
   tcp:
-    configMapNamespace: default
+    configMapNamespace: ${NAMESPACE}
   udp:
-    configMapNamespace: default
+    configMapNamespace: ${NAMESPACE}
 
 tcp:
-  9000: "default/test:8080"
+  9000: "${NAMESPACE}/test:8080"
 
 udp:
-  9001: "default/test:8080"
+  9001: "${NAMESPACE}/test:8080"

--- a/prow/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
+++ b/prow/nginx-ingress/ci/daemonset-tcp-udp-configMapNamespace-values.yaml
@@ -3,12 +3,12 @@ controller:
   service:
     type: ClusterIP
   tcp:
-    configMapNamespace: ${NAMESPACE}
+    configMapNamespace: default
   udp:
-    configMapNamespace: ${NAMESPACE}
+    configMapNamespace: default
 
 tcp:
-  9000: "${NAMESPACE}/test:8080"
+  9000: "default/test:8080"
 
 udp:
-  9001: "${NAMESPACE}/test:8080"
+  9001: "default/test:8080"

--- a/prow/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/prow/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -2,12 +2,12 @@ controller:
   service:
     type: ClusterIP
   tcp:
-    configMapNamespace: ${NAMESPACE}
+    configMapNamespace: default
   udp:
-    configMapNamespace: ${NAMESPACE}
+    configMapNamespace: default
 
 tcp:
-  9000: "${NAMESPACE}/test:8080"
+  9000: "default/test:8080"
 
 udp:
-  9001: "${NAMESPACE}/test:8080"
+  9001: "default/test:8080"

--- a/prow/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
+++ b/prow/nginx-ingress/ci/deployment-tcp-udp-configMapNamespace-values.yaml
@@ -2,12 +2,12 @@ controller:
   service:
     type: ClusterIP
   tcp:
-    configMapNamespace: default
+    configMapNamespace: ${NAMESPACE}
   udp:
-    configMapNamespace: default
+    configMapNamespace: ${NAMESPACE}
 
 tcp:
-  9000: "default/test:8080"
+  9000: "${NAMESPACE}/test:8080"
 
 udp:
-  9001: "default/test:8080"
+  9001: "${NAMESPACE}/test:8080"

--- a/prow/setup-prow-deployer.sh
+++ b/prow/setup-prow-deployer.sh
@@ -71,14 +71,14 @@ set_kube_config_values() {
 }
 
 create_clusterrolebinding() {
-    kubectl create clusterrolebinding ${SERVICE_ACCOUNT_NAME}-binding \
+    kubectl create clusterrolebinding "${SERVICE_ACCOUNT_NAME}-binding" \
         --clusterrole=cluster-admin \
-        --serviceaccount=${NAMESPACE}:${SERVICE_ACCOUNT_NAME}
+        --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT_NAME}"
 }
 
 create_secret() {
-    kubectl create secret generic ${SERVICE_ACCOUNT_NAME}-kubeconfig \
-        --from-file=kubeconfig.yaml=${KUBECFG_FILE_NAME} \
+    kubectl create secret generic "${SERVICE_ACCOUNT_NAME}-kubeconfig" \
+        --from-file=kubeconfig.yaml="${KUBECFG_FILE_NAME}" \
         --namespace test-pods
 }
 

--- a/prow/setup-prow-deployer.sh
+++ b/prow/setup-prow-deployer.sh
@@ -2,8 +2,8 @@
 set -e
 set -o pipefail
 
-SERVICE_ACCOUNT_NAME="prow-deployer"
-NAMESPACE="default"
+SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-prow-deployer}
+NAMESPACE=${NAMESPACE:-default}
 KUBECFG_FILE_NAME="secrets/${SERVICE_ACCOUNT_NAME}-kubeconfig"
 TARGET_FOLDER="/tmp"
 

--- a/prow/setup-prow-deployer.sh
+++ b/prow/setup-prow-deployer.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-prow-deployer}
 NAMESPACE=${NAMESPACE:-default}
+WORKER_NS=${WORKER_NS:-test-pods}
 KUBECFG_FILE_NAME="secrets/${SERVICE_ACCOUNT_NAME}-kubeconfig"
 TARGET_FOLDER="/tmp"
 
@@ -79,7 +80,7 @@ create_clusterrolebinding() {
 create_secret() {
     kubectl create secret generic "${SERVICE_ACCOUNT_NAME}-kubeconfig" \
         --from-file=kubeconfig.yaml="${KUBECFG_FILE_NAME}" \
-        --namespace test-pods
+        --namespace "${WORKER_NS}"
 }
 
 create_service_account

--- a/prow/setup-prow-deployer.sh
+++ b/prow/setup-prow-deployer.sh
@@ -74,13 +74,13 @@ set_kube_config_values() {
 create_clusterrolebinding() {
     kubectl create clusterrolebinding "${SERVICE_ACCOUNT_NAME}-binding" \
         --clusterrole=cluster-admin \
-        --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT_NAME}"
+        --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT_NAME}" || echo Skipping
 }
 
 create_secret() {
     kubectl create secret generic "${SERVICE_ACCOUNT_NAME}-kubeconfig" \
         --from-file=kubeconfig.yaml="${KUBECFG_FILE_NAME}" \
-        --namespace "${WORKER_NS}"
+        --namespace "${WORKER_NS}" || echo Skipping
 }
 
 create_service_account

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -11,7 +11,7 @@ WORKER_NS=${WORKER_NS:-test-pods}
 (kubectl get nodes | grep prow-worker-01) || (echo "Wrong cluster. Exiting..."; exit 1)
 
 # make sure we use the latest configuration
-sh gen-config.sh
+./gen-config.sh
 
 # update config and plugins
 kubectl -n "${NAMESPACE}" create configmap config --from-file=config.yaml=config.gen.yaml --dry-run -o yaml | kubectl -n default replace configmap config -f -

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -20,7 +20,7 @@ kubectl -n "${NAMESPACE}" create configmap plugins --from-file=plugins.yaml=plug
 # update deployments etc.
 for file in "${DIR}"/cluster/*; do
   # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be expanded
-  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' 's@${WORKER_NS}@'"${WORKER_NS}"'@' "$file" | kubectl apply -f -
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "$file" | kubectl apply -f -
 done
 
 # restart deployments

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -20,7 +20,7 @@ kubectl -n "${NAMESPACE}" create configmap plugins --from-file=plugins.yaml=plug
 # update deployments etc.
 for file in "${DIR}"/cluster/*; do
   # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be expanded
-  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@' "$file" | kubectl apply -f -
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@g' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@g' "$file" | kubectl apply -f -
 done
 
 # restart deployments

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -19,8 +19,8 @@ kubectl -n "${NAMESPACE}" create configmap plugins --from-file=plugins.yaml=plug
 
 # update deployments etc.
 for file in "${DIR}"/cluster/*; do
-  # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be replaced
-  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' 's@${WORKER_NS}@'"${WORKER_NS}"'@' $file | kubectl apply -f -
+  # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be expanded
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' 's@${WORKER_NS}@'"${WORKER_NS}"'@' "$file" | kubectl apply -f -
 done
 
 # restart deployments

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -18,7 +18,8 @@ kubectl -n "${NAMESPACE}" create configmap config --from-file=config.yaml=config
 kubectl -n "${NAMESPACE}" create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl -n default replace configmap plugins -f -
 
 # update deployments etc.
-for file in ${DIR}/cluster/*; do
+for file in "${DIR}"/cluster/*; do
+  # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be replaced
   sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' 's@${WORKER_NS}@'"${WORKER_NS}"'@' $file | kubectl apply -f -
 done
 

--- a/prow/update.sh
+++ b/prow/update.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAMESPACE=${NAMESPACE:-default}
+WORKER_NS=${WORKER_NS:-test-pods}
+
 # safety measure: make sure we're on the right cluster
 (kubectl get nodes | grep prow-worker-01) || (echo "Wrong cluster. Exiting..."; exit 1)
 
@@ -9,15 +14,15 @@ set -ex
 sh gen-config.sh
 
 # update config and plugins
-kubectl -n default create configmap config --from-file=config.yaml=config.gen.yaml --dry-run -o yaml | kubectl -n default replace configmap config -f -
-kubectl -n default create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl -n default replace configmap plugins -f -
+kubectl -n "${NAMESPACE}" create configmap config --from-file=config.yaml=config.gen.yaml --dry-run -o yaml | kubectl -n default replace configmap config -f -
+kubectl -n "${NAMESPACE}" create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl -n default replace configmap plugins -f -
 
 # update deployments etc.
-for file in cluster/*; do
-  kubectl apply -f "${file}"
+for file in ${DIR}/cluster/*; do
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@' 's@${WORKER_NS}@'"${WORKER_NS}"'@' $file | kubectl apply -f -
 done
 
 # restart deployments
 for deployment in $(kubectl get deployments -n default -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
-  kubectl -n default rollout restart deployment "${deployment}"
+  kubectl -n "${NAMESPACE}" rollout restart deployment "${deployment}"
 done


### PR DESCRIPTION
This PR allows customizing both prow namespace as well as the one where jobs run. 

Additionally, I improved both `config-gen.sh` and `update.sh` so that they can be invoked from anywhere, not only from within the directory they are in.