### PR TITLE
Bump k8s test-infra tools to match deployed version

### DIFF
--- a/docker/maistra-proxy-builder_1.1.Dockerfile
+++ b/docker/maistra-proxy-builder_1.1.Dockerfile
@@ -5,7 +5,7 @@ ENV K8S_TEST_INFRA_VERSION=41512c7491a99c6bdf330e1a76d45c8a10d3679b
 
 RUN dnf -y upgrade --refresh && \
     dnf -y install dnf-plugins-core https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf -y config-manager --set-enabled PowerTools && \
+    dnf -y config-manager --set-enabled powertools && \
     dnf -y install git make libtool patch libatomic which \
                    autoconf automake libtool cmake python2 python3 \
                    gcc gcc-c++ ninja-build golang annobin libstdc++-static \

--- a/docker/maistra-proxy-builder_2.0.Dockerfile
+++ b/docker/maistra-proxy-builder_2.0.Dockerfile
@@ -6,7 +6,7 @@ ENV GCLOUD_VERSION=312.0.0
 
 RUN dnf -y upgrade --refresh && \
     dnf -y install dnf-plugins-core https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf -y config-manager --set-enabled PowerTools && \
+    dnf -y config-manager --set-enabled powertools && \
     dnf -y install git make libtool patch libatomic which \
                    autoconf automake libtool cmake python2 python3 \
                    gcc gcc-c++ ninja-build golang annobin libstdc++-static \

--- a/docker/maistra-proxy-builder_2.0.Dockerfile
+++ b/docker/maistra-proxy-builder_2.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 
 # Versions
-ENV K8S_TEST_INFRA_VERSION=41512c7491a99c6bdf330e1a76d45c8a10d3679b
+ENV K8S_TEST_INFRA_VERSION=229d6b4c8d1eb4c0ccc00342ad21089068e0b827
 ENV GCLOUD_VERSION=312.0.0
 
 RUN dnf -y upgrade --refresh && \
@@ -18,9 +18,11 @@ RUN curl -o /usr/bin/bazel -Ls https://github.com/bazelbuild/bazel/releases/down
     chmod +x /usr/bin/bazel
 
 # Go tools
-ENV GOBIN=/usr/local/bin
-RUN GO111MODULE=off go get github.com/myitcv/gobin && \
-    gobin k8s.io/test-infra/robots/pr-creator@${K8S_TEST_INFRA_VERSION}
+RUN git clone https://github.com/kubernetes/test-infra.git /root/test-infra && \
+    cd /root/test-infra && git checkout ${K8S_TEST_INFRA_VERSION} && \
+    go build -o /usr/local/bin/checkconfig prow/cmd/checkconfig/main.go && \
+    go build -o /usr/local/bin/pr-creator robots/pr-creator/main.go && \
+    rm -rf /root/* /root/.cache /tmp/*
 
 ENV CC=gcc CXX=g++ USER=user HOME=/home/user
 RUN mkdir -p /home/user && chmod 777 /home/user


### PR DESCRIPTION
`gobin` approach is not working, throws several errors, `go get` also shows issues.
Switching to a local build works.

While on that, group other `go get` commands together, to save space.