### PR TITLE
Fix hook RBAC

### DIFF
--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -17,6 +17,8 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - update
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Add missing verbs, keeping in sync with k8s prow.

This fixes the cases when a PR is closed but jobs are
not aborted, when they should.

Hook logs show:
```
{"author":"dmitri-d","component":"hook","error":"failed to abort jobs: failed to list prowjobs for pr: prowjobs.prow.k8s.io is forbidden: User \"system:serviceaccount:default:hook\" cannot list resource \"prowjobs\" in API group \"prow.k8s.io\" in the namespace \"default\"","event-GUID":"a22ebc00-5a99-11eb-9145-70495511e85a","event-type":"pull_request","file":"prow/hook/events.go:203","func":"k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent.func1","level":"error","msg":"Error handling PullRequestEvent.","org":"maistra","plugin":"trigger","pr":60,"repo":"envoy","severity":"error","time":"2021-01-19T21:02:28Z","url":"https://github.com/maistra/envoy/pull/60"}
```