### PR TITLE
Add support for prow jobs for 2.1

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -626,6 +626,50 @@ presubmits:
             memory: 4Gi
     trigger: "(?m)^/test check-links"
     rerun_command: "/test check-links"
+  - name: maistra.github.io_lint
+    decorate: true
+    always_run: true
+    skip_report: false
+    branches:
+      - maistra-2.1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        resources:
+          limits:
+            memory: 8Gi
+            cpu: "4"
+          requests:
+            cpu: "2"
+            memory: 4Gi
+    trigger: "(?m)^/test lint"
+    rerun_command: "/test lint"
+  - name: maistra.github.io_check-links
+    decorate: true
+    always_run: true
+    skip_report: false
+    branches:
+      - maistra-2.1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - check-links
+        resources:
+          limits:
+            memory: 8Gi
+            cpu: "4"
+          requests:
+            cpu: "2"
+            memory: 4Gi
+    trigger: "(?m)^/test check-links"
+    rerun_command: "/test check-links"
   maistra/istio-operator:
   - name: istio-operator_unittests
     decorate: true

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -88,6 +88,50 @@ presubmits:
             memory: 4Gi
     trigger: "(?m)^/test check-links"
     rerun_command: "/test check-links"
+  - name: maistra.github.io_lint
+    decorate: true
+    always_run: true
+    skip_report: false
+    branches:
+      - maistra-2.1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        resources:
+          limits:
+            memory: 8Gi
+            cpu: "4"
+          requests:
+            cpu: "2"
+            memory: 4Gi
+    trigger: "(?m)^/test lint"
+    rerun_command: "/test lint"
+  - name: maistra.github.io_check-links
+    decorate: true
+    always_run: true
+    skip_report: false
+    branches:
+      - maistra-2.1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - check-links
+        resources:
+          limits:
+            memory: 8Gi
+            cpu: "4"
+          requests:
+            cpu: "2"
+            memory: 4Gi
+    trigger: "(?m)^/test check-links"
+    rerun_command: "/test check-links"
   maistra/istio-operator:
   - name: istio-operator_unittests
     decorate: true


### PR DESCRIPTION
Looks like we missed some repos when we set up 2.1... test infra looks like it's also missing. Should I add it?