### PR TITLE
Fix "don't squash" label usage

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1987,7 +1987,7 @@ github_reporter:
   - postsubmit
 
 tide:
-  merge_label: "don't squash"
+  rebase_label: "don't squash"
   merge_method:
     maistra: squash
     dgn: squash

--- a/prow/config/tide.yaml
+++ b/prow/config/tide.yaml
@@ -4,7 +4,7 @@ github_reporter:
   - postsubmit
 
 tide:
-  merge_label: "don't squash"
+  rebase_label: "don't squash"
   merge_method:
     maistra: squash
     dgn: squash


### PR DESCRIPTION
We're currently using Merge commits instead of rebasing when we add the "don't squash" label. I noticed this while looking at the [commit history for maistra/istio](https://github.com/maistra/istio/commits/maistra-2.1)