### PR TITLE
Set --github-token-path arg on missing deployments

### DIFF
--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - --dry-run=false
         - --use-prow-assignments=false
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         ports:
         - name: http
           containerPort: 8888

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         - --github-workers=1
         - --config-path=/etc/config/config.yaml
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=https://api.github.com
         - --config-path=/etc/config/config.yaml
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8888


### PR DESCRIPTION
It's mandatory now. Some deployments already have it.