### PR TITLE
No need for promu build

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1189,6 +1189,9 @@ presubmits:
         - make
         - build
         - test
+        env:
+        - name: BUILD_PROMU
+          value: "false"
         resources:
           limits:
             memory: 16Gi

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -528,6 +528,9 @@ presubmits:
         - make
         - build
         - test
+        env:
+        - name: BUILD_PROMU
+          value: "false"
         resources:
           limits:
             memory: 16Gi


### PR DESCRIPTION
We supply a released promu, so no need to build it.

@jwendell 