### PR TITLE
OSSM-755 Update maistra-builder:2.1 to fedora:34

### DIFF
--- a/docker/maistra-builder_2.1.Dockerfile
+++ b/docker/maistra-builder_2.1.Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/kubernetes/test-infra.git /root/test-infra && \
     go build -o /usr/local/bin/checkconfig prow/cmd/checkconfig/main.go && \
     go build -o /usr/local/bin/pr-creator robots/pr-creator/main.go
 
-FROM fedora:33
+FROM fedora:34
 
 # Versions
 ENV ISTIO_TOOLS_SHA=f4cf625fd815a0300e5ca541d03bc57057dad289
@@ -50,7 +50,7 @@ RUN curl -sfL https://download.docker.com/linux/fedora/docker-ce.repo -o /etc/yu
                    make automake gcc gcc-c++ git which \
                    docker-ce npm python3-pip rubygems cmake \
                    rubygem-asciidoctor ruby-devel zlib-devel \
-                   openssl-devel && \
+                   openssl-devel rubygem-rexml && \
     dnf -y clean all
 
 # Go tools


### PR DESCRIPTION
~This seems to fix the problems we're seeing with integration tests. Theory is that `golang` was outdated/broken in the current `maistra-builder` image (or `fedora:33` in general) which somehow ended up causing problems with the security integration tests because SDS would not work correctly.~

Only fixed problems locally. Still doesn't work on prow :(