### PR TITLE
Mount overlay fs from host in integration tests

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -2330,6 +2330,9 @@ presubmits:
         - mountPath: /sys/fs/cgroup
           name: cgroup
           readOnly: true
+        - mountPath: /var/lib/docker/overlay2
+          name: overlay2
+          readOnly: false
         resources:
           limits:
             memory: 24Gi
@@ -2346,6 +2349,10 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - hostPath:
+          path: /var/lib/docker/overlay2
+          type: Directory
+        name: overlay2
   - name: istio_2.2-integration-maistra-mc
     trigger: (?m)^/test( | .* )integration\-maistra\-mc,?($|\s.*)
     rerun_command: /test integration-maistra-mc
@@ -2385,6 +2392,9 @@ presubmits:
         - mountPath: /sys/fs/cgroup
           name: cgroup
           readOnly: true
+        - mountPath: /var/lib/docker/overlay2
+          name: overlay2
+          readOnly: false
         resources:
           limits:
             memory: 24Gi
@@ -2401,6 +2411,10 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - hostPath:
+          path: /var/lib/docker/overlay2
+          type: Directory
+        name: overlay2
 
   - name: istio_2.0-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -1391,6 +1391,9 @@ presubmits:
         - mountPath: /sys/fs/cgroup
           name: cgroup
           readOnly: true
+        - mountPath: /var/lib/docker/overlay2
+          name: overlay2
+          readOnly: false
         resources:
           limits:
             memory: 24Gi
@@ -1407,6 +1410,10 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - hostPath:
+          path: /var/lib/docker/overlay2
+          type: Directory
+        name: overlay2
   - name: istio_2.2-integration-maistra-mc
     trigger: (?m)^/test( | .* )integration\-maistra\-mc,?($|\s.*)
     rerun_command: /test integration-maistra-mc
@@ -1446,6 +1453,9 @@ presubmits:
         - mountPath: /sys/fs/cgroup
           name: cgroup
           readOnly: true
+        - mountPath: /var/lib/docker/overlay2
+          name: overlay2
+          readOnly: false
         resources:
           limits:
             memory: 24Gi
@@ -1462,6 +1472,10 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+      - hostPath:
+          path: /var/lib/docker/overlay2
+          type: Directory
+        name: overlay2
 
   - name: istio_2.0-unit
     trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
Apparently this is necessary to run docker in docker (kind) nowadays.