### PR TITLE
Attempt to fix the job hanging forever

### DIFF
--- a/docker/scripts/prow-entrypoint-main.sh
+++ b/docker/scripts/prow-entrypoint-main.sh
@@ -31,7 +31,7 @@ if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
 fi
 
 # Start docker daemon and wait for dockerd to start
-dockerd &
+dockerd --debug > "${ARTIFACTS:-}/dockerd.log" 2>&1 &
 
 log "Waiting for dockerd to start..."
 while :
@@ -50,6 +50,7 @@ function cleanup() {
   # shellcheck disable=SC2046
   docker kill $(docker ps -q) || true
   docker system prune -af || true
+  pkill -9 dockerd
   log "Cleanup complete"
 }
 


### PR DESCRIPTION
By explicitly killing the docker daemon at the entrypoint exit.

Also, put docker daemon log in a separate file, to make it easy to read
the job logs. This file will be available in the artifacts dir, on prow
website for the job.