### PR TITLE
Fix the volume mount for 2.2 jobs

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1464,6 +1464,10 @@ presubmits:
         - build-containers
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -1471,6 +1475,10 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
+
   - name: test-infra_build-proxy-containers
     decorate: true
     path_alias: github.com/maistra/test-infra
@@ -1489,6 +1497,10 @@ presubmits:
         - build-proxy-containers
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -1496,6 +1508,9 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
   maistra/prometheus:
   - name: prometheus-test
     decorate: true
@@ -2623,6 +2638,10 @@ presubmits:
         - container
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -2630,6 +2649,9 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
 
   - name: header-append-filter_test
     decorate: true

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -593,6 +593,10 @@ presubmits:
         - build-containers
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -600,6 +604,10 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
+
   - name: test-infra_build-proxy-containers
     decorate: true
     path_alias: github.com/maistra/test-infra
@@ -618,6 +626,10 @@ presubmits:
         - build-proxy-containers
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -625,6 +637,9 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
   maistra/prometheus:
   - name: prometheus-test
     decorate: true
@@ -1752,6 +1767,10 @@ presubmits:
         - container
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -1759,6 +1778,9 @@ presubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
 
   - name: header-append-filter_test
     decorate: true


### PR DESCRIPTION
`/var/lib/docker` needs to be mounted on the host so that overlay2 fs
works in a docker-in-docker environment.

https://stackoverflow.com/questions/67953609/overlay2-driver-not-supported

Follows up on a430096a2f82b38d673dfff7f9edcc42da2d79dd.