### PR TITLE
fix(prow): adds missing watch for prowjobs in hook and hologrium

### DIFF
--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -19,6 +19,7 @@ rules:
       - get
       - list
       - update
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/prow/cluster/horologium_rbac.yaml
+++ b/prow/cluster/horologium_rbac.yaml
@@ -17,6 +17,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Without this, you can see errors in the logs of both services as they are unable to watch for created `ProwJob` resources.