### PR TITLE
fix(gen-config): adds extra line between files

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -16,6 +16,7 @@ branch-protection:
       required_pull_request_reviews:
         required_approving_review_count: 2
         require_code_owner_reviews: false
+
 deck:
   spyglass:
     size_limit: 500000000  # 500 MB
@@ -46,6 +47,7 @@ deck:
         name: podinfo
       required_files:
       - podinfo.json
+
 periodics:
 - name: merge-upstream-envoy
   decorate: true
@@ -80,6 +82,7 @@ periodics:
         requests:
           cpu: "1"
           memory: 1Gi
+
 plank:
   job_url_prefix_config:
     '*': "https://prow.maistra.io/view/"
@@ -98,6 +101,7 @@ plank:
       gcs_credentials_secret: "gcs-credentials"
   pod_unscheduled_timeout: 6h
   pod_pending_timeout: 6h
+
 postsubmits:
   maistra/test-infra:
   - name: test-infra_deploy-prow
@@ -764,6 +768,7 @@ postsubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+
 presets:
 - labels:
     preset-prow-deployer: "true"
@@ -869,6 +874,7 @@ presets:
       secretKeyRef:
         name: aws
         key: QUAY_PULL_SECRET
+
 presubmits:
   maistra/maistra.github.io:
   - name: maistra.github.io_lint
@@ -2896,12 +2902,15 @@ presubmits:
           requests:
             cpu: "2"
             memory: 2Gi
+
 prowjob_namespace: default
 pod_namespace: test-pods
+
 sinker:
   resync_period: 1h
   max_prowjob_age: 168h
   max_pod_age: 6h
+
 github_reporter:
   job_types_to_report:
   - presubmit
@@ -2961,3 +2970,4 @@ tide:
     labels:
     - auto-merge
     reviewApprovedRequired: false
+

--- a/prow/gen-config.sh
+++ b/prow/gen-config.sh
@@ -7,15 +7,17 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 NAMESPACE=${NAMESPACE:-default}
 WORKER_NS=${WORKER_NS:-test-pods}
 
+GEN_CONFIG_FILE="${DIR}/config.gen.yaml"
 # re-generate config
 echo "#======================================
 # This configuration is auto-generated. 
 # To update:
 #    Modify files in the config directory
 #    Run gen-config.sh to regenerate.
-#======================================" > config.gen.yaml
+#======================================" > "${GEN_CONFIG_FILE}"
 
 for file in "${DIR}"/config/*; do
   # shellcheck disable=SC2016 ## in case of sed expression first '' is not an actual variable to be expanded
-  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@g' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@g' "${file}" >> "${DIR}"/config.gen.yaml
+  sed -e 's@${NAMESPACE}@'"${NAMESPACE}"'@g' -e 's@${WORKER_NS}@'"${WORKER_NS}"'@g' "${file}" >> "${GEN_CONFIG_FILE}"
+  printf '\n' >> "${GEN_CONFIG_FILE}"
 done


### PR DESCRIPTION
This way it is not needed to add it in each and every file which is then concatenated by gen-config.

Additionally keeps the YAML file location in one variable to ensure it is consistently used during the whole process.