### PR TITLE
Make sure the bazel-cache tolerates the master node taint

### DIFF
--- a/prow/cluster/bazel-cache-deployment.yaml
+++ b/prow/cluster/bazel-cache-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: bazel-cache
     spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
       nodeSelector:
         kubernetes.io/hostname: prow-master-03 # This could be a proper label such as `role: bazel-cache`
 


### PR DESCRIPTION
This is necessary to allow the kubelet to schedule onto a master node