### PR TITLE
Install libstdc++-static in 2.2 builder image

### DIFF
--- a/docker/maistra-builder_2.2.Dockerfile
+++ b/docker/maistra-builder_2.2.Dockerfile
@@ -67,9 +67,8 @@ RUN curl -sfL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yu
     dnf -y module reset ruby nodejs && dnf -y module enable ruby:2.7 nodejs:12 && dnf -y module install ruby nodejs && \
     dnf -y install --nodocs --setopt=install_weak_deps=False \
                    git make libtool patch which ninja-build golang xz redhat-rpm-config \
-                   autoconf automake libtool cmake python2 python3 \
+                   autoconf automake libtool cmake python2 python3 libstdc++-static \
                    gcc-toolset-9 gcc-toolset-9-libatomic-devel gcc-toolset-9-annobin gcc-toolset-9-libasan-devel \
-                   gcc-toolset-11 gcc-toolset-11-libatomic-devel gcc-toolset-11-annobin-plugin-gcc gcc-toolset-11-libasan-devel\
                    java-11-openjdk-devel jq file diffutils lbzip2 annobin-annocheck \
                    clang llvm lld ruby-devel zlib-devel openssl-devel python2-setuptools \
                    binaryen emsdk docker-ce python3-pip rubygems npm rpm-build && \


### PR DESCRIPTION
It's necessary to build with clang.

Also remove gcc 11, it is not (and never was) used.