### PR TITLE
Add the tide blocker_label field

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -3178,6 +3178,7 @@ github_reporter:
   - postsubmit
 
 tide:
+  blocker_label: merge-blocker
   rebase_label: "don't squash"
   merge_label: "merge strategy"
   merge_method:

--- a/prow/config/tide.yaml
+++ b/prow/config/tide.yaml
@@ -4,6 +4,7 @@ github_reporter:
   - postsubmit
 
 tide:
+  blocker_label: merge-blocker
   rebase_label: "don't squash"
   merge_label: "merge strategy"
   merge_method:


### PR DESCRIPTION
It allows us to block unwanted merges on frozen branches.

https://github.com/kubernetes/test-infra/blob/d3d9042df51d37827cbec36b536158221ff47117/prow/cmd/tide/config.md#merge-blocker-issues