### PR TITLE
Stop setting the CI environment variable in our images

### DIFF
--- a/docker/maistra-builder_2.0.Dockerfile
+++ b/docker/maistra-builder_2.0.Dockerfile
@@ -38,10 +38,6 @@ ENV HUGO_VERSION="0.69.2"
 
 ENV GOPROXY="https://proxy.golang.org,direct"
 
-# Set CI variable which can be checked by test scripts to verify
-# if running in the continuous integration environment.
-ENV CI prow
-
 # Install all dependencies available in RPM repos
 RUN curl -sfL https://download.docker.com/linux/fedora/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo && \
     dnf -y update && \

--- a/docker/maistra-builder_2.1.Dockerfile
+++ b/docker/maistra-builder_2.1.Dockerfile
@@ -39,10 +39,6 @@ ENV HUGO_VERSION="0.69.2"
 
 ENV GOPROXY="https://proxy.golang.org,direct"
 
-# Set CI variable which can be checked by test scripts to verify
-# if running in the continuous integration environment.
-ENV CI prow
-
 # Install all dependencies available in RPM repos
 RUN curl -sfL https://download.docker.com/linux/fedora/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo && \
     dnf -y update && \

--- a/docker/maistra-builder_2.2.Dockerfile
+++ b/docker/maistra-builder_2.2.Dockerfile
@@ -50,10 +50,6 @@ ENV GOSUMDB=sum.golang.org
 ENV GOPATH=/go
 ENV GOCACHE=/gocache
 
-# Set CI variable which can be checked by test scripts to verify
-# if running in the continuous integration environment.
-ENV CI prow
-
 WORKDIR /root
 
 # Install all dependencies available in RPM repos

--- a/docker/maistra-builder_2.3.Dockerfile
+++ b/docker/maistra-builder_2.3.Dockerfile
@@ -50,10 +50,6 @@ ENV GOSUMDB=sum.golang.org
 ENV GOPATH=/go
 ENV GOCACHE=/gocache
 
-# Set CI variable which can be checked by test scripts to verify
-# if running in the continuous integration environment.
-ENV CI prow
-
 WORKDIR /root
 
 # Install all dependencies available in RPM repos

--- a/docker/maistra-builder_main.Dockerfile
+++ b/docker/maistra-builder_main.Dockerfile
@@ -43,10 +43,6 @@ ENV GOPROXY="https://proxy.golang.org,direct"
 ENV GO111MODULE=on
 ENV GOBIN=/usr/local/bin
 
-# Set CI variable which can be checked by test scripts to verify
-# if running in the continuous integration environment.
-ENV CI prow
-
 WORKDIR /root
 
 # Install all dependencies available in RPM repos


### PR DESCRIPTION
Strip "ENV CI prow" from our build images.

According to https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
we can expect prow to do it for us.

This will be helpful in non-ci (dev) flows as it voids
the need for devs to suppress this variable.

Related discussion https://github.com/maistra/envoy/pull/179

Signed-off-by: Otto van der Schaaf <ovanders@redhat.com>