### PR TITLE
Ignore non-prow statuses on PRs

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -3754,6 +3754,8 @@ tide:
   target_url: https://prow.maistra.io/tide
   context_options:
     from-branch-protection: true
+    # Treat unknown contexts as optional
+    skip-unknown-contexts: true
 
   queries:
 

--- a/prow/config/tide.yaml
+++ b/prow/config/tide.yaml
@@ -13,6 +13,8 @@ tide:
   target_url: https://prow.maistra.io/tide
   context_options:
     from-branch-protection: true
+    # Treat unknown contexts as optional
+    skip-unknown-contexts: true
 
   queries:
 


### PR DESCRIPTION
This change will force prow to only treat jobs as required that have been marked as such in the branch protection settings.