### PR TITLE
Revert "Remove redundant jobs for Istio and Istio Operator"

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1403,6 +1403,139 @@ presubmits:
             cpu: "4"
             memory: 4Gi
 
+  - name: istio-operator_unittests-2.2
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.2$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - compile
+        - test
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: TEST_FLAGS
+          value: -v
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+  - name: istio-operator_gen-check-2.2
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.2$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - gen-check
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-operator_unittests-2.3
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.3$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - make
+        - compile
+        - test
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: TEST_FLAGS
+          value: -v
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+  - name: istio-operator_gen-check-2.3
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.3$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - make
+        - gen-check
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+  - name: istio-operator_lint-2.3
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.3$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        resources:
+          limits:
+            memory: 4Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 2Gi
+
   maistra/test-infra:
   - name: test-infra_lint
     decorate: true
@@ -2006,6 +2139,120 @@ presubmits:
             memory: 4Gi
 
   maistra/istio:
+  - name: istio-unit-2.1
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.1$
+    rerun_command: /test unit
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - -e
+        - T=-v
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-lint-2.1
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.1$
+    rerun_command: /test lint
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-gencheck-2.1
+    trigger: (?m)^/test( | .* )gencheck,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.1$
+    rerun_command: /test gencheck
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+      # TODO: uncomment once it's back on the branch
+      # - maistra-gen-k8s-client
+        - gen-check
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
   - name: istio-integration-2.1
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
     rerun_command: /test integration
@@ -2110,6 +2357,123 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+
+  - name: istio-unit-2.2
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.2$
+    rerun_command: /test unit
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - -e
+        - T=-v
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        # FIXME: Uncomment this when we have our 2.2 proxy in place
+        # - name: ISTIO_ENVOY_BASE_URL
+        #   value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-lint-2.2
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.2$
+    rerun_command: /test lint
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        # FIXME: Uncomment this when we have our 2.2 proxy in place
+        # - name: ISTIO_ENVOY_BASE_URL
+        #   value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-gencheck-2.2
+    trigger: (?m)^/test( | .* )gencheck,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.2$
+    rerun_command: /test gencheck
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+      # TODO: uncomment once it's back on the branch
+      # - maistra-gen-k8s-client
+        - gen-check
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        # FIXME: Uncomment this when we have our 2.2 proxy in place
+        # - name: ISTIO_ENVOY_BASE_URL
+        #   value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
 
   - name: istio-integration-2.2
     trigger: (?m)^/test( | .* )integration,?($|\s.*)

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -460,6 +460,139 @@ presubmits:
             cpu: "4"
             memory: 4Gi
 
+  - name: istio-operator_unittests-2.2
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.2$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - compile
+        - test
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: TEST_FLAGS
+          value: -v
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+  - name: istio-operator_gen-check-2.2
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.2$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - gen-check
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-operator_unittests-2.3
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.3$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - make
+        - compile
+        - test
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: TEST_FLAGS
+          value: -v
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+  - name: istio-operator_gen-check-2.3
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.3$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - make
+        - gen-check
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+  - name: istio-operator_lint-2.3
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - ^maistra-2.3$
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        resources:
+          limits:
+            memory: 4Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 2Gi
+
   maistra/test-infra:
   - name: test-infra_lint
     decorate: true
@@ -1063,6 +1196,120 @@ presubmits:
             memory: 4Gi
 
   maistra/istio:
+  - name: istio-unit-2.1
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.1$
+    rerun_command: /test unit
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - -e
+        - T=-v
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-lint-2.1
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.1$
+    rerun_command: /test lint
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-gencheck-2.1
+    trigger: (?m)^/test( | .* )gencheck,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.1$
+    rerun_command: /test gencheck
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - make
+      # TODO: uncomment once it's back on the branch
+      # - maistra-gen-k8s-client
+        - gen-check
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        - name: ISTIO_ENVOY_BASE_URL
+          value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
   - name: istio-integration-2.1
     trigger: (?m)^/test( | .* )integration,?($|\s.*)
     rerun_command: /test integration
@@ -1167,6 +1414,123 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+
+  - name: istio-unit-2.2
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.2$
+    rerun_command: /test unit
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - -e
+        - T=-v
+        - build
+        - racetest
+        - binaries-test
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        # FIXME: Uncomment this when we have our 2.2 proxy in place
+        # - name: ISTIO_ENVOY_BASE_URL
+        #   value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-lint-2.2
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.2$
+    rerun_command: /test lint
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+        - lint
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        # FIXME: Uncomment this when we have our 2.2 proxy in place
+        # - name: ISTIO_ENVOY_BASE_URL
+        #   value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 24Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: istio-gencheck-2.2
+    trigger: (?m)^/test( | .* )gencheck,?($|\s.*)
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    max_concurrency: 2
+    branches:
+      - ^maistra-2.2$
+    rerun_command: /test gencheck
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - make
+      # TODO: uncomment once it's back on the branch
+      # - maistra-gen-k8s-client
+        - gen-check
+        env:
+        - name: BUILD_WITH_CONTAINER
+          value: "0"
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+        # FIXME: Uncomment this when we have our 2.2 proxy in place
+        # - name: ISTIO_ENVOY_BASE_URL
+        #   value: https://storage.googleapis.com/maistra-prow-testing/proxy
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
 
   - name: istio-integration-2.2
     trigger: (?m)^/test( | .* )integration,?($|\s.*)


### PR DESCRIPTION
Reverts maistra/test-infra#264

Let's keep the jobs around until we stabilize OpenShift CI jobs.