### PR TITLE
Install protoc-gen-deepcopy in maistra-builder:2.3

### DIFF
--- a/docker/maistra-builder_2.3.Dockerfile
+++ b/docker/maistra-builder_2.3.Dockerfile
@@ -76,7 +76,6 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${GOLANG_PROTOBUF_VE
     go install github.com/gogo/protobuf/protoc-gen-gogofast@${GOGO_PROTOBUF_VERSION} && \
     go install github.com/gogo/protobuf/protoc-gen-gogofaster@${GOGO_PROTOBUF_VERSION} && \
     go install github.com/gogo/protobuf/protoc-gen-gogoslick@${GOGO_PROTOBUF_VERSION} && \
-    go install github.com/protobuf-tools/protoc-gen-deepcopy@v0.0.3 && \
     \
     go install github.com/uber/prototool/cmd/prototool@${PROTOTOOL_VERSION} && \
     go install github.com/nilslice/protolock/cmd/protolock@${PROTOLOCK_VERSION} && \
@@ -99,7 +98,7 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${GOLANG_PROTOBUF_VE
     go install istio.io/tools/cmd/cue-gen@${ISTIO_TOOLS_SHA} && \
     go install istio.io/tools/cmd/envvarlinter@${ISTIO_TOOLS_SHA} && \
     go install istio.io/tools/cmd/testlinter@${ISTIO_TOOLS_SHA} && \
-    go install istio.io/tools/cmd/protoc-gen-golang-deepcopy@${ISTIO_TOOLS_SHA} && \
+    go install istio.io/tools/cmd/protoc-gen-deepcopy@${ISTIO_TOOLS_SHA} && \
     go install istio.io/tools/cmd/protoc-gen-golang-jsonshim@${ISTIO_TOOLS_SHA} && \
     go install istio.io/tools/cmd/kubetype-gen@${ISTIO_TOOLS_SHA} && \
     go install istio.io/tools/cmd/license-lint@${ISTIO_TOOLS_SHA} && \

--- a/docker/maistra-builder_2.3.Dockerfile
+++ b/docker/maistra-builder_2.3.Dockerfile
@@ -76,6 +76,7 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${GOLANG_PROTOBUF_VE
     go install github.com/gogo/protobuf/protoc-gen-gogofast@${GOGO_PROTOBUF_VERSION} && \
     go install github.com/gogo/protobuf/protoc-gen-gogofaster@${GOGO_PROTOBUF_VERSION} && \
     go install github.com/gogo/protobuf/protoc-gen-gogoslick@${GOGO_PROTOBUF_VERSION} && \
+    go install github.com/protobuf-tools/protoc-gen-deepcopy@v0.0.3 && \
     \
     go install github.com/uber/prototool/cmd/prototool@${PROTOTOOL_VERSION} && \
     go install github.com/nilslice/protolock/cmd/protolock@${PROTOLOCK_VERSION} && \

--- a/tools/automator-main.sh
+++ b/tools/automator-main.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 ROOT="$(cd -P "$(dirname -- "$0")" && pwd -P)"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "$ROOT/utils.sh"
 
 cleanup() {


### PR DESCRIPTION
After [upgrading dependencies in maistra/api](https://github.com/maistra/api/pull/36), gen-check started to fail, because of missing `protoc-gen-deepcopy`.

Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>