### PR TITLE
Split post-submit push jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,36 @@ BUILD_IMAGE_VERSIONS = $(BUILD_IMAGE)_2.3 $(BUILD_IMAGE)_2.2 $(BUILD_IMAGE)_2.1 
 
 ${BUILD_IMAGE}: $(BUILD_IMAGE_VERSIONS)
 
+# Build a specific maistra image. Example of usage: make maistra-builder_2.3
 ${BUILD_IMAGE}_%:
 	$(CONTAINER_CLI) build -t ${HUB}/${BUILD_IMAGE}:$* \
 				 -f docker/$@.Dockerfile docker
 
+# Build and push all maistra images. Example of usage: make maistra-builder.push
 ${BUILD_IMAGE}.push: ${BUILD_IMAGE}
 	$(CONTAINER_CLI) push --all-tags ${HUB}/${BUILD_IMAGE}
+
+# Build and push a specific maistra image. Example of usage: make maistra-builder_2.3.push
+${BUILD_IMAGE}_%.push: ${BUILD_IMAGE}_%
+	$(CONTAINER_CLI) push ${HUB}/${BUILD_IMAGE}:$*
 
 BUILD_PROXY_IMAGE = maistra-proxy-builder
 BUILD_PROXY_IMAGE_VERSIONS = $(BUILD_PROXY_IMAGE)_2.1 $(BUILD_PROXY_IMAGE)_2.0
 
 ${BUILD_PROXY_IMAGE}: $(BUILD_PROXY_IMAGE_VERSIONS)
 
+# Build a specific proxy image. Example of usage: make maistra-proxy-builder_2.1
 ${BUILD_PROXY_IMAGE}_%:
 	$(CONTAINER_CLI) build -t ${HUB}/${BUILD_PROXY_IMAGE}:$* \
 				 -f docker/$@.Dockerfile docker
 
+# Build and push all proxy images. Example of usage: make maistra-proxy-builder.push
 ${BUILD_PROXY_IMAGE}.push: ${BUILD_PROXY_IMAGE}
 	$(CONTAINER_CLI) push --all-tags ${HUB}/${BUILD_PROXY_IMAGE}
+
+# Build and push a specific proxy image. Example of usage: make maistra-proxy-builder_2.1.push
+${BUILD_PROXY_IMAGE}_%.push: ${BUILD_PROXY_IMAGE}_%
+	$(CONTAINER_CLI) push ${HUB}/${BUILD_PROXY_IMAGE}:$*
 
 gen-check: gen check-clean-repo
 

--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -172,11 +172,11 @@ postsubmits:
             cpu: "2"
             memory: 1Gi
 
-  - name: test-infra_push-containers
+  - name: test-infra_push-containers-2.0
     decorate: true
     path_alias: github.com/maistra/test-infra
     skip_report: false
-    run_if_changed: '^docker/maistra-builder_.*\.Dockerfile|^docker/scripts'
+    run_if_changed: '^docker/maistra-builder_2\.0\.Dockerfile|^docker/scripts'
     branches:
       - main
     labels:
@@ -189,7 +189,7 @@ postsubmits:
         command:
         - entrypoint
         - make
-        - maistra-builder.push
+        - maistra-builder_2.0.push
         securityContext:
           privileged: true
         resources:
@@ -200,11 +200,95 @@ postsubmits:
             cpu: "4"
             memory: 4Gi
 
-  - name: test-infra_push-proxy-containers
+  - name: test-infra_push-containers-2.1
     decorate: true
     path_alias: github.com/maistra/test-infra
     skip_report: false
-    run_if_changed: '^docker/maistra-proxy-builder_.*\.Dockerfile'
+    run_if_changed: '^docker/maistra-builder_2\.1\.Dockerfile|^docker/scripts'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder_2.1.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-containers-2.2
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-builder_2\.2\.Dockerfile|^docker/scripts'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder_2.2.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-containers-2.3
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-builder_2\.3\.Dockerfile|^docker/scripts'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder_2.3.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-proxy-containers-2.0
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-proxy-builder_2\.0\.Dockerfile'
     branches:
       - main
     labels:
@@ -217,7 +301,35 @@ postsubmits:
         command:
         - entrypoint
         - make
-        - maistra-proxy-builder.push
+        - maistra-proxy-builder_2.0.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-proxy-containers-2.1
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-proxy-builder_2\.1\.Dockerfile'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-proxy-builder_2.1.push
         securityContext:
           privileged: true
         resources:

--- a/prow/config/postsubmits.yaml
+++ b/prow/config/postsubmits.yaml
@@ -25,11 +25,11 @@ postsubmits:
             cpu: "2"
             memory: 1Gi
 
-  - name: test-infra_push-containers
+  - name: test-infra_push-containers-2.0
     decorate: true
     path_alias: github.com/maistra/test-infra
     skip_report: false
-    run_if_changed: '^docker/maistra-builder_.*\.Dockerfile|^docker/scripts'
+    run_if_changed: '^docker/maistra-builder_2\.0\.Dockerfile|^docker/scripts'
     branches:
       - main
     labels:
@@ -42,7 +42,7 @@ postsubmits:
         command:
         - entrypoint
         - make
-        - maistra-builder.push
+        - maistra-builder_2.0.push
         securityContext:
           privileged: true
         resources:
@@ -53,11 +53,95 @@ postsubmits:
             cpu: "4"
             memory: 4Gi
 
-  - name: test-infra_push-proxy-containers
+  - name: test-infra_push-containers-2.1
     decorate: true
     path_alias: github.com/maistra/test-infra
     skip_report: false
-    run_if_changed: '^docker/maistra-proxy-builder_.*\.Dockerfile'
+    run_if_changed: '^docker/maistra-builder_2\.1\.Dockerfile|^docker/scripts'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder_2.1.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-containers-2.2
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-builder_2\.2\.Dockerfile|^docker/scripts'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder_2.2.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-containers-2.3
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-builder_2\.3\.Dockerfile|^docker/scripts'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder_2.3.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-proxy-containers-2.0
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-proxy-builder_2\.0\.Dockerfile'
     branches:
       - main
     labels:
@@ -70,7 +154,35 @@ postsubmits:
         command:
         - entrypoint
         - make
-        - maistra-proxy-builder.push
+        - maistra-proxy-builder_2.0.push
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 16Gi
+            cpu: "4"
+          requests:
+            cpu: "4"
+            memory: 4Gi
+
+  - name: test-infra_push-proxy-containers-2.1
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/maistra-proxy-builder_2\.1\.Dockerfile'
+    branches:
+      - main
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra-dev/maistra-builder:2.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-proxy-builder_2.1.push
         securityContext:
           privileged: true
         resources:

--- a/tools/automator-main.sh
+++ b/tools/automator-main.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 ROOT="$(cd -P "$(dirname -- "$0")" && pwd -P)"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "$ROOT/utils.sh"
 
 cleanup() {


### PR DESCRIPTION
Into one for each version. Currently if we only touch one Dockerfile the post submit job builds and pushes all versions. This is unnecessary and is a waste of resources and time.