### PR TITLE
Fix the error with libatomic on 2.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ lint:
 
 # these will build the containers and then try to use them to build themselves again, making sure we didn't break docker support
 build-containers-%: ${BUILD_IMAGE}_%
-	$(CONTAINER_CLI) run --privileged -v ${PWD}:/work --workdir /work  --entrypoint entrypoint ${HUB}/maistra-builder:$* make maistra-builder_$*
+	$(CONTAINER_CLI) run --privileged -v ${PWD}:/work --workdir /work -v /var/lib/docker --entrypoint entrypoint ${HUB}/maistra-builder:$* make maistra-builder_$*

--- a/docker/maistra-builder_2.3.Dockerfile
+++ b/docker/maistra-builder_2.3.Dockerfile
@@ -53,6 +53,7 @@ ENV GOCACHE=/gocache
 WORKDIR /root
 
 # Install all dependencies available in RPM repos
+# Stick with clang 14.0.0 which depends on gcc 11 which has the package gcc-toolset-11-libatomic-devel (latest clang depends on gcc 12 which does not have this package yet)
 RUN curl -sfL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo && \
     curl -sfL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo && \
     dnf -y upgrade --refresh && \
@@ -65,8 +66,8 @@ RUN curl -sfL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yu
                    git make libtool patch which ninja-build golang xz redhat-rpm-config \
                    autoconf automake libtool cmake python2 libstdc++-static \
                    java-11-openjdk-devel jq file diffutils lbzip2 annobin-annocheck \
-                   ruby-devel zlib-devel openssl-devel python2-setuptools \
-                   clang llvm lld compiler-rt libatomic \
+                   ruby-devel zlib-devel openssl-devel python2-setuptools gcc-toolset-11-libatomic-devel \
+                   clang-0:14.0.0-1.module_el8.7.0+1142+5343df54 llvm-0:14.0.6-1.module_el8.7.0+1198+0c3eb6e2 lld-0:14.0.6-1.module_el8.7.0+1198+0c3eb6e2 compiler-rt-0:14.0.0-3.module_el8.7.0+1149+a59781f0 \
                    binaryen emsdk docker-ce rubygems npm yarn rpm-build && \
     dnf -y clean all
 


### PR DESCRIPTION
`ld.lld: error: unable to find library -latomic`

This was likely due to an update to clang and its dependencies. Stcking with an old clang might fix this issue.