### PR TITLE
Fix the daily build

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -74,6 +74,9 @@ periodics:
       - ./create-images.sh
       - -tDAILY
       - -p
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
       securityContext:
         privileged: true
       volumeMounts:
@@ -108,6 +111,9 @@ periodics:
       - ./create-images.sh
       - -tDAILY
       - -p
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
       securityContext:
         privileged: true
       volumeMounts:

--- a/prow/config/periodics.yaml
+++ b/prow/config/periodics.yaml
@@ -17,6 +17,9 @@ periodics:
       - ./create-images.sh
       - -tDAILY
       - -p
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
       securityContext:
         privileged: true
       volumeMounts:
@@ -51,6 +54,9 @@ periodics:
       - ./create-images.sh
       - -tDAILY
       - -p
+      env:
+      - name: BUILD_WITH_CONTAINER
+        value: "0"
       securityContext:
         privileged: true
       volumeMounts:


### PR DESCRIPTION
By setting the `BUILD_WITH_CONTAINER` variable to "0". Without it, the istio build was happening within a nested container, and, as the variable `DOCKER_CONFIG` is not being forwarded to this nested container, the push to quay.io fails due the missing credentials.

We don't need this nested container as the build already happens in our builder image, as it is with the pre-submit jobs.