### PR TITLE
Add CONTAINER_CLI var for maistra-2.2 daily builds

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -77,6 +77,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: CONTAINER_CLI
+        value: "docker"
       securityContext:
         privileged: true
       volumeMounts:

--- a/prow/config/periodics.yaml
+++ b/prow/config/periodics.yaml
@@ -20,6 +20,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: CONTAINER_CLI
+        value: "docker"
       securityContext:
         privileged: true
       volumeMounts:


### PR DESCRIPTION
If `BUILD_WITH_CONTAINER=0` the `CONTAINER_CLI` environment variable is not [set](https://github.com/maistra/istio/blob/maistra-2.2/common/scripts/setup_env.sh#L173-L183) 