### PR TITLE
Fix daily build for 2.3

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1082,15 +1082,15 @@ presets:
     preset-quay-pusher: "true"
   env:
   - name: DOCKER_CONFIG
-    value: /creds/
+    value: /docker-config
   - name: HUB
     value: quay.io/maistra-dev
   volumeMounts:
-  - name: creds
-    mountPath: /creds
-    readOnly: true
+  - name: docker-config
+    mountPath: /docker-config
+    readOnly: false
   volumes:
-  - name: creds
+  - name: docker-config
     secret:
       secretName: quay-pusher-dockercfg
 

--- a/prow/config/presets.yaml
+++ b/prow/config/presets.yaml
@@ -17,15 +17,15 @@ presets:
     preset-quay-pusher: "true"
   env:
   - name: DOCKER_CONFIG
-    value: /creds/
+    value: /docker-config
   - name: HUB
     value: quay.io/maistra-dev
   volumeMounts:
-  - name: creds
-    mountPath: /creds
-    readOnly: true
+  - name: docker-config
+    mountPath: /docker-config
+    readOnly: false
   volumes:
-  - name: creds
+  - name: docker-config
     secret:
       secretName: quay-pusher-dockercfg
 


### PR DESCRIPTION
By making the docker config directory writable. `docker buildx` creates a `buildx` subdirectory in it. If the volume is read only, the job fails.

While on it, also change the name of the volume mounts so it doesn't clash with other mounts. Change from `creds` to `docker-config` which is more accurate.