### PR TITLE
Fix daily build for 2.3

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -77,6 +77,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: BUILDX_CONFIG
+        value: /tmp
       securityContext:
         privileged: true
       volumeMounts:
@@ -114,6 +116,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: BUILDX_CONFIG
+        value: /tmp
       securityContext:
         privileged: true
       volumeMounts:

--- a/prow/config/periodics.yaml
+++ b/prow/config/periodics.yaml
@@ -20,6 +20,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: BUILDX_CONFIG
+        value: /tmp
       securityContext:
         privileged: true
       volumeMounts:
@@ -57,6 +59,8 @@ periodics:
       env:
       - name: BUILD_WITH_CONTAINER
         value: "0"
+      - name: BUILDX_CONFIG
+        value: /tmp
       securityContext:
         privileged: true
       volumeMounts:


### PR DESCRIPTION
By setting  the env variable `$BUILDX_CONFIG` to a writable directory.

- https://github.com/docker/buildx/blob/c5aec243c9a3e43cd45ac16e7232e7cae92abb3e/docs/reference/buildx_create.md#-specify-a-configuration-file-for-the-buildkitd-daemon---config
- https://github.com/docker/buildx/blob/c5aec243c9a3e43cd45ac16e7232e7cae92abb3e/util/confutil/config.go#L17