### PR TITLE
OSSM-2175: Allow writes to /rust dir

### DIFF
--- a/docker/maistra-builder_2.2.Dockerfile
+++ b/docker/maistra-builder_2.2.Dockerfile
@@ -212,7 +212,7 @@ RUN curl -o /usr/bin/bazel -Ls https://github.com/bazelbuild/bazel/releases/down
 # Rust (for WASM filters)
 ENV CARGO_HOME "/rust"
 ENV RUSTUP_HOME "/rust"
-RUN mkdir /rust && \
+RUN mkdir /rust && chmod 777 /rust && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     /rust/bin/rustup target add wasm32-unknown-unknown
 ENV PATH=/usr/local/google-cloud-sdk/bin:/rust/bin:$PATH

--- a/docker/maistra-builder_2.3.Dockerfile
+++ b/docker/maistra-builder_2.3.Dockerfile
@@ -213,7 +213,7 @@ RUN curl -o /usr/bin/bazel -Ls https://github.com/bazelbuild/bazel/releases/down
 # Rust (for WASM filters)
 ENV CARGO_HOME "/rust"
 ENV RUSTUP_HOME "/rust"
-RUN mkdir /rust && \
+RUN mkdir /rust && chmod 777 /rust && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     /rust/bin/rustup target add wasm32-unknown-unknown
 ENV PATH=/usr/local/google-cloud-sdk/bin:/rust/bin:$PATH


### PR DESCRIPTION
So that jobs that run as non-root can properly write on it (e.g., rust cache modules).

Openshift CI jobs runs as non-root users.