### PR TITLE
OSSM-2175: Jobs for header-append-filter

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1043,15 +1043,14 @@ postsubmits:
     path_alias: github.com/maistra/header-append-filter
     skip_report: false
     branches:
+      - maistra-2.3
       - maistra-2.2
-      - maistra-2.1
-      - maistra-2.0
     labels:
       preset-quay-pusher: "true"
     max_concurrency: 1
     spec:
       containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.0"
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
         imagePullPolicy: Always
         command:
         - entrypoint
@@ -2943,15 +2942,12 @@ presubmits:
     skip_report: false
     always_run: true
     branches:
+      - ^maistra-2.3$
       - ^maistra-2.2$
-      - ^maistra-2.1$
-      - ^maistra-2.0$
-      # Allow for testing
-      - playground
     max_concurrency: 2
     spec:
       containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
         imagePullPolicy: Always
         command:
         - entrypoint
@@ -2973,58 +2969,6 @@ presubmits:
       volumes:
       - emptyDir: {}
         name: varlibdocker
-
-  - name: header-append-filter_test
-    decorate: true
-    path_alias: github.com/maistra/header-append-filter
-    skip_report: false
-    always_run: true
-    branches:
-      - ^maistra-2.2$
-      - ^maistra-2.1$
-      # Allow for testing
-      - playground
-    max_concurrency: 2
-    spec:
-      containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.2"
-        imagePullPolicy: Always
-        command:
-        - make
-        - test
-        resources:
-          limits:
-            memory: 16Gi
-            cpu: "4"
-          requests:
-            cpu: "2"
-            memory: 4Gi
-
-  - name: header-append-filter_lint
-    decorate: true
-    path_alias: github.com/maistra/header-append-filter
-    skip_report: false
-    always_run: true
-    branches:
-      - ^maistra-2.2$
-      - ^maistra-2.1$
-      # Allow for testing
-      - playground
-    max_concurrency: 2
-    spec:
-      containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.2"
-        imagePullPolicy: Always
-        command:
-        - make
-        - lint
-        resources:
-          limits:
-            memory: 16Gi
-            cpu: "4"
-          requests:
-            cpu: "1"
-            memory: 2Gi
 
   maistra/istio-must-gather:
   - name: istio-must-gather_lint

--- a/prow/config/postsubmits.yaml
+++ b/prow/config/postsubmits.yaml
@@ -888,15 +888,14 @@ postsubmits:
     path_alias: github.com/maistra/header-append-filter
     skip_report: false
     branches:
+      - maistra-2.3
       - maistra-2.2
-      - maistra-2.1
-      - maistra-2.0
     labels:
       preset-quay-pusher: "true"
     max_concurrency: 1
     spec:
       containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.0"
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
         imagePullPolicy: Always
         command:
         - entrypoint

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -1768,15 +1768,12 @@ presubmits:
     skip_report: false
     always_run: true
     branches:
+      - ^maistra-2.3$
       - ^maistra-2.2$
-      - ^maistra-2.1$
-      - ^maistra-2.0$
-      # Allow for testing
-      - playground
     max_concurrency: 2
     spec:
       containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.2"
+      - image: "quay.io/maistra-dev/maistra-builder:2.3"
         imagePullPolicy: Always
         command:
         - entrypoint
@@ -1798,58 +1795,6 @@ presubmits:
       volumes:
       - emptyDir: {}
         name: varlibdocker
-
-  - name: header-append-filter_test
-    decorate: true
-    path_alias: github.com/maistra/header-append-filter
-    skip_report: false
-    always_run: true
-    branches:
-      - ^maistra-2.2$
-      - ^maistra-2.1$
-      # Allow for testing
-      - playground
-    max_concurrency: 2
-    spec:
-      containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.2"
-        imagePullPolicy: Always
-        command:
-        - make
-        - test
-        resources:
-          limits:
-            memory: 16Gi
-            cpu: "4"
-          requests:
-            cpu: "2"
-            memory: 4Gi
-
-  - name: header-append-filter_lint
-    decorate: true
-    path_alias: github.com/maistra/header-append-filter
-    skip_report: false
-    always_run: true
-    branches:
-      - ^maistra-2.2$
-      - ^maistra-2.1$
-      # Allow for testing
-      - playground
-    max_concurrency: 2
-    spec:
-      containers:
-      - image: "quay.io/maistra-dev/maistra-builder:2.2"
-        imagePullPolicy: Always
-        command:
-        - make
-        - lint
-        resources:
-          limits:
-            memory: 16Gi
-            cpu: "4"
-          requests:
-            cpu: "1"
-            memory: 2Gi
 
   maistra/istio-must-gather:
   - name: istio-must-gather_lint


### PR DESCRIPTION
- Add job for 2.3
- Remove jobs that were moved to OpenShift CI
- Remove jobs for 2.0 and 2.1 - They are obsolete now