### PR TITLE
Fix the post-submit job for header-append

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1058,6 +1058,10 @@ postsubmits:
         - container.push
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -1065,6 +1069,9 @@ postsubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker
 
 presets:
 - labels:

--- a/prow/config/postsubmits.yaml
+++ b/prow/config/postsubmits.yaml
@@ -903,6 +903,10 @@ postsubmits:
         - container.push
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/docker
+          name: varlibdocker
+          readOnly: false
         resources:
           limits:
             memory: 16Gi
@@ -910,3 +914,6 @@ postsubmits:
           requests:
             cpu: "4"
             memory: 4Gi
+      volumes:
+      - emptyDir: {}
+        name: varlibdocker


### PR DESCRIPTION
By setting the volume for docker, otherwise we get the error:

```
error creating aufs mount to /var/lib/docker/aufs/mnt/db696b0cd021f5796351f4f3a47c4fbceb8a6e71eb50e4e6ea10830f55623f32: mount target=/var/lib/docker/aufs/mnt/db696b0cd021f5796351f4f3a47c4fbceb8a6e71eb50e4e6ea10830f55623f32 data=br:/var/lib/docker/aufs/diff/db696b0cd021f5796351f4f3a47c4fbceb8a6e71eb50e4e6ea10830f55623f32=rw:/var/lib/docker/aufs/diff/db696b0cd021f5796351f4f3a47c4fbceb8a6e71eb50e4e6ea10830f55623f32-init=ro+wh,dio,xino=/dev/shm/aufs.xino: invalid argument
```