### PR TITLE
OSSM-2158: uses shallow clone for test-infra

### DIFF
--- a/docker/maistra-builder_2.4.Dockerfile
+++ b/docker/maistra-builder_2.4.Dockerfile
@@ -36,7 +36,7 @@ ENV PROTOC_GEN_SWAGGER_VERSION=v1.8.6
 ENV GOCOVMERGE_VERSION=b5bfa59ec0adc420475f97f89b58045c721d761c
 ENV BENCHSTAT_VERSION=9c9101da8316
 ENV GH_VERSION=2.17.0
-ENV K8S_TEST_INFRA_VERSION=b3a9f2479e
+ENV K8S_TEST_INFRA_VERSION=b3a9f2479edd51c1da898c2073bab8512de275ec
 ENV BUF_VERSION=v1.8.0
 ENV GCLOUD_VERSION=405.0.1
 ENV SU_EXEC_VERSION=0.2
@@ -121,8 +121,12 @@ RUN go install -ldflags="-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@${G
     go install -ldflags="-s -w" k8s.io/code-generator/cmd/go-to-protobuf@kubernetes-${K8S_CODE_GENERATOR_VERSION} && \
     \
     # pr creator
-    git clone --branch master --single-branch https://github.com/kubernetes/test-infra.git /root/test-infra && \
-    cd /root/test-infra && git checkout ${K8S_TEST_INFRA_VERSION} && \
+    mkdir -p /root/test-infra && \
+    cd /root/test-infra && \
+    git init && \
+    git remote add origin https://github.com/kubernetes/test-infra.git && \
+    git fetch --depth 1 origin ${K8S_TEST_INFRA_VERSION} && \
+    git checkout FETCH_HEAD && \
     go install ./robots/pr-creator && \
     go install ./prow/cmd/peribolos && \
     go install ./prow/cmd/checkconfig && \
@@ -132,15 +136,6 @@ RUN go install -ldflags="-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@${G
 
 # YQ
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq-go && chmod +x /usr/local/bin/yq-go
-
-# pr-creator
-RUN git clone --branch master --single-branch https://github.com/kubernetes/test-infra.git /root/test-infra && \
-    cd /root/test-infra && git checkout ${K8S_TEST_INFRA_VERSION} && \
-    go install ./robots/pr-creator && \
-    go install ./prow/cmd/peribolos && \
-    go install ./prow/cmd/checkconfig && \
-    go install ./pkg/benchmarkjunit && \
-    rm -rf /root/* /root/.cache /tmp/* /gocache/* /go/pkg
 
 # GH CLI
 RUN curl -sfLO https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz && \

--- a/docker/maistra-builder_2.4.Dockerfile
+++ b/docker/maistra-builder_2.4.Dockerfile
@@ -78,7 +78,7 @@ RUN curl -sfL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yu
 
 # Install go 1.19
 # FIXME: Replace with go from centos dnf repo when 1.19 is available
-RUN curl -sfL https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar zx -C /usr/local
+RUN curl -sfL https://go.dev/dl/go1.19.3.linux-amd64.tar.gz | tar zx -C /usr/local
 
 # Build and install a bunch of Go tools
 RUN go install -ldflags="-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@${GOLANG_PROTOBUF_VERSION} && \

--- a/docker/maistra-builder_2.4.Dockerfile
+++ b/docker/maistra-builder_2.4.Dockerfile
@@ -19,7 +19,6 @@ ENV K8S_CODE_GENERATOR_VERSION=1.25.0
 ENV LICENSEE_VERSION=9.15.1
 ENV GOLANG_PROTOBUF_VERSION=v1.28.1
 ENV GOLANG_GRPC_PROTOBUF_VERSION=v1.2.0
-ENV FPM_VERSION=1.12.0
 ENV SHELLCHECK_VERSION=v0.8.0
 ENV JUNIT_MERGER_VERSION=adf1545b49509db1f83c49d1de90bbcb235642a8
 ENV PROMU_VERSION=0.7.0
@@ -200,9 +199,12 @@ RUN curl -o /usr/bin/bazel -Ls https://github.com/bazelbuild/bazel/releases/down
     chmod +x /usr/bin/bazel
 
 # FPM
-RUN git clone https://github.com/jordansissel/fpm /tmp/fpm && \
+RUN mkdir -p /tmp/fpm && \
     cd /tmp/fpm && \
-    git reset --hard ${FPM_VERSION} && \
+    git init && \ 
+    git remote add origin https://github.com/jordansissel/fpm && \
+    git fetch --depth 1 origin ${FPM_VERSION} && \
+    git checkout FETCH_HEAD && \
     make install && \
     rm -rf /tmp/*
 

--- a/tools/bump_prow.sh
+++ b/tools/bump_prow.sh
@@ -64,7 +64,9 @@ function run_sed() {
 
   local sha
   sha=$(echo "${VERSION}" | cut -d- -f2)
-  local filter_dockerfile="s|ENV K8S_TEST_INFRA_VERSION=.*|ENV K8S_TEST_INFRA_VERSION=${sha}|"
+  local longSha
+  longSha=$(curl -sLf https://api.github.com/repos/kubernetes/test-infra/commits/"${sha}" | grep -Po '(?<="sha": ")[^"]*' | head -n 1)
+  local filter_dockerfile="s|ENV K8S_TEST_INFRA_VERSION=.*|ENV K8S_TEST_INFRA_VERSION=${longSha}|"
   find docker -name '*Dockerfile' -print0 | xargs -0 -r sed -i "${filter_dockerfile}"
 }
 


### PR DESCRIPTION
Instead of cloning the repository to perform tool installations we can fetch arbitrary sha/tag instead. This reduces the amount of data transferred.

Note: needs full commit hash at the moment.


Additionally removes duplicated `test-infra` installation.