### PR TITLE
Show job status in PR for operator push-image job

### DIFF
--- a/prow/config.gen.yaml
+++ b/prow/config.gen.yaml
@@ -1322,7 +1322,7 @@ presubmits:
   - name: istio-operator-push-image-2.3
     trigger: (?m)^/push\-image,?($|\s.*)
     rerun_command: /push-image
-    skip_report: true
+    skip_report: false
     max_concurrency: 2
     always_run: false
     branches:
@@ -1377,7 +1377,7 @@ presubmits:
   - name: istio-operator-push-image-2.4
     trigger: (?m)^/push\-image,?($|\s.*)
     rerun_command: /push-image
-    skip_report: true
+    skip_report: false
     max_concurrency: 2
     always_run: false
     branches:

--- a/prow/config/presubmits.yaml
+++ b/prow/config/presubmits.yaml
@@ -105,7 +105,7 @@ presubmits:
   - name: istio-operator-push-image-2.3
     trigger: (?m)^/push\-image,?($|\s.*)
     rerun_command: /push-image
-    skip_report: true
+    skip_report: false
     max_concurrency: 2
     always_run: false
     branches:
@@ -160,7 +160,7 @@ presubmits:
   - name: istio-operator-push-image-2.4
     trigger: (?m)^/push\-image,?($|\s.*)
     rerun_command: /push-image
-    skip_report: true
+    skip_report: false
     max_concurrency: 2
     always_run: false
     branches:


### PR DESCRIPTION
We're showing a status for the /push-images job in maistra/istio, but not this one. Let's show it, it's annoying if you have to look for it on https://prow.maistra.io