### PR TITLE
OSSM-3621: Fix fetch-args logic

### DIFF
--- a/tools/automator-main.sh
+++ b/tools/automator-main.sh
@@ -292,9 +292,8 @@ merge() {
   fork_name="$src_branch-$branch-$modifier-$(hash "$title")"
 
   if $fetch_tags; then
-    merge_branch="$(git describe --tags --abbrev=0 "$merge_branch")"
-    git remote add upstream "$merge_repository"
-    git fetch upstream tag "$merge_branch"
+    git remote add -f upstream "$merge_repository"
+    merge_branch="$(git describe --tags --abbrev=0 "upstream/$merge_branch")"
     echo "Using tag $merge_branch"
   else
     git remote add -f -t "$merge_branch" upstream "$merge_repository"
@@ -316,7 +315,7 @@ merge() {
     issue_exists=$(gh issue list -S "Automatic merge of $merge_branch into $branch failed." -R "$org/$repo" | wc -l)
     if [ "$issue_exists" -eq 0 ]; then
       # shellcheck disable=SC2086
-      gh issue create -b "Automatic merge of upstream ($merge_branch branch) into $org/$repo ($branch branch) failed. ${merge_failure_notify:-}" -t "Automatic merge of upstream failed" ${merge_failure_label:-} -R "$org/$repo"
+      gh issue create -b "Automatic merge of upstream ($merge_branch) into $org/$repo ($branch branch) failed. ${merge_failure_notify:-}" -t "Automatic merge of upstream failed" ${merge_failure_label:-} -R "$org/$repo"
       print_error "Conflicts detected, manual merge is required. An issue in $org/$repo has been created." 0
     else
       print_error "Conflicts detected, manual merge is required. An issue in $org/$repo already exists." 0


### PR DESCRIPTION
We need to first fetch the upstream remote before attempting to list the tags. Also we must prefix the argument for `git describe` with the remote name (`upstream`).

Otherwise we get this:
```
fatal: Not a valid object name release-1.16
```
as seen in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/41421/rehearse-41421-periodic-ci-maistra-test-infra-main-sync-upstream-istio-2.4/1681626569493188608