### PR TITLE
Add 777 permission for go/gocache subfolders

### DIFF
--- a/docker/maistra-builder_2.5.Dockerfile
+++ b/docker/maistra-builder_2.5.Dockerfile
@@ -428,8 +428,8 @@ RUN mkdir -p /go && \
 # They are created as root 755.  As a result they are not writeable, which fails in
 # the developer environment as a volume or bind mount inherits the permissions of
 # the directory mounted rather then overriding with the permission of the volume file.
-RUN chmod 777 /go && \
-    chmod 777 /gocache && \
+RUN chmod -R 777 /go && \
+    chmod -R 777 /gocache && \
     chmod 777 /gobin && \
     chmod 777 /config && \
     chmod 777 /config/.docker && \


### PR DESCRIPTION
Added 777 permission for all folders in /go and /gocache since there are already some folders there ( in comparison to 2.4 version ) which causes  a permission error in the maistra-test-tool ci (during make build) :https://github.com/openshift/release/pull/50225