### PR TITLE
Simplify make build for non multi arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ${BUILD_IMAGE}_%.push:
 			$(MAKE) ${BUILD_IMAGE}_$*; \
 			$(CONTAINER_CLI) manifest push ${HUB}/${BUILD_IMAGE}:$*; \
 		else \
-			BUILDX_OUTPUT="--push" make ${BUILD_IMAGE}_$*; \
+			BUILDX_OUTPUT="--push" make ${BUILD_IMAGE}_$*_multi; \
 	        fi \
 	else \
 		echo "Building and pushing single-platform image"; \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUILDX_BUILD_ARGS = --build-arg TARGETOS=$(TARGET_OS)
 # Only build single arch image by using the build command
 ${BUILD_IMAGE}_%:
 	echo "Building single-platform image with $(CONTAINER_CLI)"; \
-	$(CONTAINER_CLI) build -t ${HUB}/${BUILD_IMAGE}:$* -f docker/$@.Dockerfile docker; \
+	$(CONTAINER_CLI) build -t ${HUB}/${BUILD_IMAGE}:$* -f docker/$@.Dockerfile docker;
 
 # Build a maistra version for the platforms described in the PLATFORMS var. 
 # Example of usage: make maistra-builder_2.5_multi
@@ -56,11 +56,11 @@ ${BUILD_IMAGE}_%.push:
 	if [ $(firstword $(subst ., ,$*)) -ge 2 -a $(word 2, $(subst ., ,$*)) -ge 5 ]; then \
 		echo "Building and pushing multi-platform image"; \
 		if [ $(CONTAINER_CLI) = "podman" ]; then \
-			$(MAKE) ${BUILD_IMAGE}_$*; \
+			$(MAKE) ${BUILD_IMAGE}_$*_multi; \
 			$(CONTAINER_CLI) manifest push ${HUB}/${BUILD_IMAGE}:$*; \
 		else \
 			BUILDX_OUTPUT="--push" make ${BUILD_IMAGE}_$*_multi; \
-	        fi \
+		fi \
 	else \
 		echo "Building and pushing single-platform image"; \
 		$(MAKE) ${BUILD_IMAGE}_$*; \

--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,10 @@ TARGET_OS ?= linux
 BUILDX_BUILD_ARGS = --build-arg TARGETOS=$(TARGET_OS)
 
 # Build a specific maistra image. Example of usage: make maistra-builder_2.3
-# This target calls the multi target if the version is >= 2.5
+# Only build single arch image by using the build command
 ${BUILD_IMAGE}_%:
-	if [ $(firstword $(subst ., ,$*)) -ge 2 -a $(word 2, $(subst ., ,$*)) -ge 5 ]; then \
-		echo "Building multi-platform image"; \
-		$(MAKE) $@_multi; \
-	else \
-		echo "Building single-platform image with $(CONTAINER_CLI)"; \
-		$(CONTAINER_CLI) build -t ${HUB}/${BUILD_IMAGE}:$* \
-				 -f docker/$@.Dockerfile docker; \
-	fi
+	echo "Building single-platform image with $(CONTAINER_CLI)"; \
+	$(CONTAINER_CLI) build -t ${HUB}/${BUILD_IMAGE}:$* -f docker/$@.Dockerfile docker; \
 
 # Build a maistra version for the platforms described in the PLATFORMS var. 
 # Example of usage: make maistra-builder_2.5_multi


### PR DESCRIPTION
The point of this PR is to not build by default the images for multi arch when the version is greater than 2.4. This will allow the user to build locally without any issue of the need to set multiple flags to build locally without any issue (buildx does not allow to use --load flag when there is more than 1 arch)