### PR TITLE
Add java to 2.6

### DIFF
--- a/docker/maistra-builder_2.6.Dockerfile
+++ b/docker/maistra-builder_2.6.Dockerfile
@@ -64,7 +64,8 @@ RUN dnf -y upgrade --refresh && dnf --enablerepo=crb -y install --setopt=install
     iproute ipset rsync net-tools \
     ninja-build \
     sudo autoconf automake cmake unzip wget xz procps dnf-plugins-core \
-    libbpf-devel
+    libbpf-devel \
+    java-11-openjdk-devel
 
 # Binary tools Versions
 ENV BENCHSTAT_VERSION=9c9101da8316


### PR DESCRIPTION
Needed for proxy builds. Not sure why it was removed in 2.6.