### PR TITLE
Replace old openssl binary

### DIFF
--- a/docker/maistra-builder_2.6.Dockerfile
+++ b/docker/maistra-builder_2.6.Dockerfile
@@ -474,7 +474,9 @@ RUN curl -sfL https://github.com/openssl/openssl/releases/download/openssl-${OPE
     ./Configure --prefix=${OPENSSL_ROOT_DIR} --openssldir=${OPENSSL_ROOT_DIR}/conf && \
     make -j4 && make install_sw && \
     echo "${OPENSSL_ROOT_DIR}/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig && \
-    cd /tmp && rm -rf /tmp/openssl-${OPENSSL_VERSION}
+    cd /tmp && rm -rf /tmp/openssl-${OPENSSL_VERSION} && \
+    rm /usr/bin/openssl || true && \
+    ln -s /opt/openssl/bin/openssl /usr/bin/openssl
 
 # su-exec is used in place of complex sudo setup operations
 RUN chmod u+sx /usr/bin/su-exec


### PR DESCRIPTION
Replaces old `openssl` binary with the new one we just downloaded.

This is an attempt to fix failures in testing maistra 2.6 PRs such as: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/maistra_istio/1070/pull-ci-maistra-istio-maistra-2.6-integ-pilot-2-6/1891489517529993216 which seem to stem from `openssl` issues.