### PR TITLE
Run 'make uninstall' and copy conf file

### DIFF
--- a/docker/maistra-builder_2.6.Dockerfile
+++ b/docker/maistra-builder_2.6.Dockerfile
@@ -472,7 +472,8 @@ ENV OPENSSL_ROOT_DIR=/opt/openssl
 RUN curl -sfL https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/openssl-${OPENSSL_VERSION} && \
     ./Configure --prefix=${OPENSSL_ROOT_DIR} --openssldir=${OPENSSL_ROOT_DIR}/conf && \
-    make -j4 && make install_sw && \
+    make uninstall && make clean && make -j4 && make install_sw && \
+    mkdir -p /opt/openssl/conf && cp /tmp/openssl-${OPENSSL_VERSION}/apps/openssl.cnf /opt/openssl/conf/openssl.cnf && \
     echo "${OPENSSL_ROOT_DIR}/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig && \
     cd /tmp && rm -rf /tmp/openssl-${OPENSSL_VERSION} && \
     rm /usr/bin/openssl || true && \

--- a/docker/maistra-builder_2.6.Dockerfile
+++ b/docker/maistra-builder_2.6.Dockerfile
@@ -472,8 +472,8 @@ ENV OPENSSL_ROOT_DIR=/opt/openssl
 RUN curl -sfL https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp && \
     cd /tmp/openssl-${OPENSSL_VERSION} && \
     ./Configure --prefix=${OPENSSL_ROOT_DIR} --openssldir=${OPENSSL_ROOT_DIR}/conf && \
-    make uninstall && make clean && make -j4 && make install_sw && \
-    mkdir -p /opt/openssl/conf && cp /tmp/openssl-${OPENSSL_VERSION}/apps/openssl.cnf /opt/openssl/conf/openssl.cnf && \
+    make -j4 && make install_sw && \
+    mkdir -p ${OPENSSL_ROOT_DIR}/conf && cp /tmp/openssl-${OPENSSL_VERSION}/apps/openssl.cnf ${OPENSSL_ROOT_DIR}/conf/openssl.cnf && \
     echo "${OPENSSL_ROOT_DIR}/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig && \
     cd /tmp && rm -rf /tmp/openssl-${OPENSSL_VERSION} && \
     rm /usr/bin/openssl || true && \


### PR DESCRIPTION
Copies openssl cnf file to expected location.

You can test this PR by:

1. Building the image
    ```
    make maistra-builder_2.6
    ```
2. Running the image locally
    ```
    docker run -it --rm quay.io/maistra-dev/maistra-builder:2.6 /bin/bash
    ```
3. Running the commands that are currently failing in `maistra/istio` tests:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/maistra_istio/1070/pull-ci-maistra-istio-maistra-2.6-maistra-istio-unit-2-6/1892635114601451520#1:build-log.txt%3A100579
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/maistra_istio/1070/pull-ci-maistra-istio-maistra-2.6-integ-pilot-2-6/1892612715663331328#1:build-log.txt%3A17499

    `mkdir` is only necessary in our manual tests because these dirs would normally be created by the tests themselves.
    ```
    mkdir -p /tmp/pki/signer/test-signer/
    /usr/bin/openssl genrsa -out /tmp/pki/signer/test-signer/root-key.pem 1024
    ```
    ```
    mkdir -p /tmp/TestTunnelingOutboundTraffic2026004584/001/
    /usr/bin/openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj /CN=external-forward-proxy.external-1-99480.svc.cluster.local -keyout /tmp/TestTunnelingOutboundTraffic2026004584/001/external-forward-proxy.external-1-99480.svc.cluster.local-key.pem -out /tmp/TestTunnelingOutboundTraffic2026004584/001/external-forward-proxy.external-1-99480.svc.cluster.local-cert.pem
    ```