### PR TITLE
builder 3.0: move rust binaries to /usr/bin

### DIFF
--- a/docker/maistra-builder_3.0.Dockerfile
+++ b/docker/maistra-builder_3.0.Dockerfile
@@ -18,7 +18,7 @@ ENV K8S_TEST_INFRA_VERSION=4f5d74517ae8ec387568f8c766f4b0ba1f454129
 # install rust 1.85 needed for ztunnel
 ARG RUST_VERSION=1.85.1
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION} && \
-    export PATH=/root/.cargo/bin:$PATH
+    mv /root/.cargo/bin/* /usr/bin/
 
 # Install all dependencies available in RPM repos
 # hadolint ignore=DL3008, DL3009


### PR DESCRIPTION
The $HOME variable is changed later in the build.
This way the binaries are still accessible.